### PR TITLE
[test-suite][Fortran] Fix failing tests from gfortran test suite

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -2322,6 +2322,12 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   write_check.f90
   zero_sized_1.f90
 
+  # ---------------------------------------------------------------------------
+  #
+  # This test fails with optimizations enabled, but succeeds when compiled
+  # without optimizations.
+  inline_transpose_1.f90
+
   # These tests fail at runtime on AArch64 (but pass on x86). Disable them
   # anyway so the test-suite passes by default on AArch64.
   entry_23.f

--- a/Fortran/gfortran/regression/EnabledFilesHLFIR.cmake
+++ b/Fortran/gfortran/regression/EnabledFilesHLFIR.cmake
@@ -28,6 +28,7 @@ file(GLOB PASSING_FILES CONFIGURE_DEPENDS
   elemental_dependency_6.f90
   forall_12.f90
   forall_17.f90
+  inline_transpose_1.f90
   internal_pack_3.f90
   missing_optional_dummy_6.f90
   mvbits_4.f90

--- a/Fortran/gfortran/torture/execute/DisabledFiles.cmake
+++ b/Fortran/gfortran/torture/execute/DisabledFiles.cmake
@@ -64,6 +64,15 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   data_3.f90
   elemental.f90
   forall_7.f90
+
+  # This file creates a string of length 10 and populates it with the name of
+  # the executable obtained from getarg(). The way the test suite is built,
+  # the executable name of the test is larger than 10 characters causing the
+  # test to fail when optimizations are enabled. This test could be re-enabled
+  # if the build system is tweaked to special case this and generate an
+  # executable whose name is 10 characters or less.
+  getarg_1.f90
+
   intrinsic_fraction_exponent.f90
   intrinsic_nearest.f90
   intrinsic_sr_kind.f90

--- a/Fortran/gfortran/torture/execute/DisabledFilesHLFIR.cmake
+++ b/Fortran/gfortran/torture/execute/DisabledFilesHLFIR.cmake
@@ -9,5 +9,4 @@
 # These tests are disabled because they fail at runtime when they should pass.
 file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   constructor.f90
-  getarg_1.f90
 )


### PR DESCRIPTION
Disable two tests that fail when optimizations are enabled, but pass otherwise. Comments have been added in the two DisabledFiles.cmake files describing why the tests were disabled.

These failures were reproduced by @kiranchandramohan  and @cabreraam on Slack.
