### PR TITLE
Fix 453.povray test on LoongArch

### DIFF
--- a/External/SPEC/CFP2006/453.povray/CMakeLists.txt
+++ b/External/SPEC/CFP2006/453.povray/CMakeLists.txt
@@ -1,8 +1,9 @@
 list(APPEND LDFLAGS -lm)
 
-if(ARCH STREQUAL "AArch64")
-  # On AArch64 and for C/C++ the new behavior is to flip 'fpp-contract' to
-  # 'on'. This breaks floating point comparison of results.
+if(ARCH STREQUAL "AArch64" OR ARCH STREQUAL "LoongArch")
+  # On AArch64/LoongArch and for C/C++ the new behavior is to flip
+  # '-ffp-contract' to 'on'. This breaks floating point comparison
+  # of results.
   # Turn off the flag so that the result image matches the reference
   # output.
   list(APPEND CXXFLAGS -ffp-contract=off)


### PR DESCRIPTION
453.povray ref test failed when running SPEC CPU2006 1.1 on a LoongArch host with clang-18.

This patch disables fp-contract to keep the generated SPEC-benchmark.tga same with the reference.

For more information about the change of the default behavior of fp-contract, see:
https://bugs.llvm.org/show_bug.cgi?id=51346