### PR TITLE
[Fortran] Disabling error tests and tests not yet working with HLFIR

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -947,6 +947,17 @@ file(GLOB UNIMPLEMENTED_FILES CONFIGURE_DEPENDS
   large_real_kind_form_io_1.f90
   norm2_3.f90
   pr96711.f90
+
+  # unimplemented: calling character elemental function with
+  # non constant character length (HLFIR regression).
+  array_temporaries_3.f90
+  pure_byref_1.f90
+
+  # unimplemented: pointer assignments inside FORALL (HLFIR
+  # regression)
+  dependency_19.f90
+  forall_3.f90
+  pr49698.f90
 )
 
 # These tests are skipped because they cannot be compiled. Unlike the
@@ -2927,4 +2938,23 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   # _OPENMP/_OPENACC directives while gfortran does.
   openacc-define-3.f90
   openmp-define-3.f90
+
+  # Tests looking for runtime errors (e.g., bound checks). Correctly
+  # caught by flang runtime when it is used for array assignments.
+  all_bounds_1.f90
+  bounds_check_12.f90
+  bounds_check_array_ctor_4.f90
+  bounds_check_fail_3.f90
+  maxloc_bounds_1.f90
+  maxloc_bounds_2.f90
+  maxloc_bounds_3.f90
+  maxloc_bounds_4.f90
+  maxloc_bounds_5.f90
+  maxloc_bounds_7.f90
+  maxloc_bounds_8.f90
+  pack_bounds_1.f90
+  spread_bounds_1.f90
+
+  # Bad test, assigning an 11 elements array to a 12 elements array.
+  transfer_array_intrinsic_4.f90
 )

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -2957,4 +2957,8 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
 
   # Bad test, assigning an 11 elements array to a 12 elements array.
   transfer_array_intrinsic_4.f90
+
+  # Fails at -O3 with HLFIR. Gfortran emits warnings when compiling,
+  # needs investigation.
+  maxlocval_1.f90
 )


### PR DESCRIPTION
Patch required before enabling HLFIR by default:
https://github.com/llvm/llvm-project/pull/72090

Three batches of tests must be disabled.
1. test using non constant length character elemental fuctions
2. test using pointer assignments inside FORALL
3. "error" test that previously "wrongly" passed (did not throw runtime errors as they should have)

For the first two batches, lowering without HFLIR handled a few cases , but did not fully handle the features correctly. With HLFIR, it was decided to make all cases TODO until the feature are handled correctly. They are not very common, hence I think the "feature regression" is acceptable for now compared to what HLFIR brings.

For, the last batch, the test suite is not set to run error checking tests (verifying a runtime error that is expected from the runtime given an invalid Fortran input), so the test suits considered a "pass" tests that where run with no error while invalid.

HLFIR with -O1 uses the runtime in cases where the previous lowering did things inline, the usage of the runtime allow catching these invalid program as expected, but since the test suit is not set up yet to deal with negative runtime tests, they must be disabled.