### PR TITLE
Port tools/timeit to windows (AArch64, x64)

### DIFF
--- a/cmake/modules/Host.cmake
+++ b/cmake/modules/Host.cmake
@@ -1,4 +1,10 @@
-set(TEST_SUITE_HOST_CC "cc" CACHE STRING "C compiler targetting the host")
+
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows" AND NOT TEST_SUITE_HOST_CC)
+  set(TEST_SUITE_HOST_CC "clang" CACHE STRING "C compiler targetting the host")
+else()
+  set(TEST_SUITE_HOST_CC "cc" CACHE STRING "C compiler targetting the host")
+endif()
+
 mark_as_advanced(TEST_SUITE_HOST_CC)
 
 function(llvm_add_host_executable targetname exename)
@@ -21,6 +27,11 @@ function(llvm_add_host_executable targetname exename)
 
     list(APPEND _objs ${_objfile})
   endforeach ()
+
+  # Append ".exe" to the executable name on Windows
+  if(WIN32)
+    set(exename "${exename}.exe")
+  endif()
 
   add_custom_command(OUTPUT ${exename}
     COMMAND ${TEST_SUITE_HOST_CC} ${_objs}


### PR DESCRIPTION
This patch implements timeit timing tool found at tools/timeit.c for Windows.
It is required for compile time and run time calculations by the llvm-testsuite.

At this moment llvm testsuite tests can not be compiled with clang-cl MSVC combination
however we have also made required modifications to the cmake files to enable building
timeit on windows with clang-cl/cl.

In developer console with MSVC following command can be used to successfully build this code:

set CC=c:\\work\\llvm-dev\\build\\bin\\clang-cl.exe
set CXX=c:\\work\\llvm-dev\\build\\bin\\clang-cl.exe

cmake -G Ninja -DTEST_SUITE_SUBDIRS= ..\\llvm-test-suite

Phabricator Review: https://reviews.llvm.org/D153263