### PR TITLE
Fix CMake modules to allow build on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,10 @@ if(TEST_SUITE_FORTRAN)
     mark_as_advanced(CLEAR CMAKE_Fortran_COMPILER)
 endif()
 
+if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND CMAKE_C_SIMULATE_ID MATCHES "MSVC")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /FIstdio.h")
+endif()
+
 # The files in cmake/caches often want to pass along additional flags to select
 # the target architecture. Note that you should still use
 # CMAKE_OSX_ARCHITECTURES and CMAKE_C_COMPILER_TARGET where possible.
@@ -299,6 +303,12 @@ mark_as_advanced(TEST_SUITE_LIT TEST_SUITE_LIT_FLAGS)
 mark_as_advanced(TEST_SUITE_LIT)
 
 add_subdirectory(tools)
+
+# Turn on ignore whitespacing on WIN32 to avoid line-ending mismatch
+if(TARGET_OS STREQUAL "Windows")
+  set(FP_IGNOREWHITESPACE ON)
+endif()
+
 # Shortcut for the path to the fpcmp executable
 set(FPCMP fpcmp-target)
 if (TEST_SUITE_USER_MODE_EMULATION)

--- a/cmake/modules/CopyDir.cmake
+++ b/cmake/modules/CopyDir.cmake
@@ -16,10 +16,17 @@ function(llvm_copy target to from)
   )
 endfunction()
 
+# On Windows create_symlink requires special permissions. Use copy_if_different instead.
+if(CMAKE_HOST_WIN32)
+  set(_link_or_copy copy_if_different)
+else()
+  set(_link_or_copy create_symlink)
+endif()
+
 function(llvm_create_symlink target to from)
   add_custom_command(
     TARGET ${target} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E create_symlink ${from} ${to}
+    COMMAND ${CMAKE_COMMAND} -E ${_link_or_copy} ${from} ${to}
   )
 endfunction()
 

--- a/cmake/modules/TestSuite.cmake
+++ b/cmake/modules/TestSuite.cmake
@@ -65,8 +65,8 @@ function(llvm_test_executable_no_test target)
 
   if(TEST_SUITE_LLVM_SIZE)
     add_custom_command(TARGET ${target} POST_BUILD
-      COMMAND ${TEST_SUITE_LLVM_SIZE} --format=sysv $<TARGET_FILE:${target}>
-      > $<TARGET_FILE:${target}>.size)
+      COMMAND ${TEST_SUITE_LLVM_SIZE} --format=sysv $<SHELL_PATH:$<TARGET_FILE:${target}>>
+      > $<SHELL_PATH:$<TARGET_FILE:${target}>>.size)
   endif()
 endfunction()
 


### PR DESCRIPTION
This patch makes some minor adjustments to top level CMakeLists.txt and CopyDir, Testsuite modules to allow testsuite build on windows.