### PR TITLE
Add find compiler-rt libs cmake module for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "AIX")
   endif()
 endif()
 
+include(HandleCompilerRT)
+
 include(TestSuite)
 include(SingleMultiSource)
 # Needs by External/sollve_vv.

--- a/cmake/modules/HandleCompilerRT.cmake
+++ b/cmake/modules/HandleCompilerRT.cmake
@@ -1,0 +1,46 @@
+# Find the path to compiler-rt builtins library for the current target and
+# and return it in `variable`.
+function(find_compiler_rt_library variable)
+  set(target "${CMAKE_CXX_COMPILER_TARGET}")
+  if(NOT CMAKE_CXX_COMPILER_TARGET AND LLVM_DEFAULT_TARGET_TRIPLE)
+    set(target "${LLVM_DEFAULT_TARGET_TRIPLE}")
+
+  if(NOT DEFINED COMPILER_RT_LIBRARY_builtins_${target} OR NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    # If the cache variable is not defined, invoke Clang and then
+    # set it with cache_compiler_rt_library.
+    set(clang_command ${CMAKE_CXX_COMPILER} "${ARG_FLAGS}")
+    if(target)
+      list(APPEND clang_command "--target=${target}")
+    endif()
+    get_property(cxx_flags CACHE CMAKE_CXX_FLAGS PROPERTY VALUE)
+    string(REPLACE " " ";" cxx_flags "${cxx_flags}")
+    list(APPEND clang_command ${cxx_flags})
+    set(cmd_prefix "")
+    if(MSVC)
+      set(cmd_prefix "/clang:")
+    endif()
+    execute_process(
+      COMMAND ${clang_command} "${cmd_prefix}--rtlib=compiler-rt" "${cmd_prefix}-print-libgcc-file-name"
+      RESULT_VARIABLE had_error
+      OUTPUT_VARIABLE library_file
+    )
+    string(STRIP "${library_file}" library_file)
+    file(TO_CMAKE_PATH "${library_file}" library_file)
+    get_filename_component(basename ${library_file} NAME)
+    if(EXISTS "${library_file}" AND (basename MATCHES ".*clang_rt\.([a-z0-9_\-]+)\.(a|lib)"))
+      message(STATUS "Found compiler-rt library: ${basename}")
+      set(COMPILER_RT_LIBRARY_builtins_${target} "${basename}" CACHE INTERNAL
+        "compiler-rt library for ${target}")
+    else()
+      message(STATUS "Failed to find compiler-rt library for ${target}")
+      set(COMPILER_RT_LIBRARY_builtins_${target} "NOTFOUND" CACHE INTERNAL
+          "compiler-rt library for ${target}")
+    endif()
+  endif()
+
+  if(NOT COMPILER_RT_LIBRARY_builtins_${target})
+    set(${variable} "NOTFOUND" PARENT_SCOPE)
+  else()
+    set(${variable} "${COMPILER_RT_LIBRARY_builtins_${target}}" PARENT_SCOPE)
+  endif()
+endfunction()

--- a/cmake/modules/HandleCompilerRT.cmake
+++ b/cmake/modules/HandleCompilerRT.cmake
@@ -1,24 +1,29 @@
-# Find the path to compiler-rt builtins library for the current target and
-# and return it in `variable`.
+# Find the path to compiler-rt builtins library for the target compiler
+# and return it in `output_variable`.
 function(find_compiler_rt_library variable)
-  set(target "${CMAKE_CXX_COMPILER_TARGET}")
-  if(NOT CMAKE_CXX_COMPILER_TARGET AND LLVM_DEFAULT_TARGET_TRIPLE)
-    set(target "${LLVM_DEFAULT_TARGET_TRIPLE}")
+  set(clang_command ${CMAKE_CXX_COMPILER})
 
-  if(NOT DEFINED COMPILER_RT_LIBRARY_builtins_${target} OR NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-    # If the cache variable is not defined, invoke Clang and then
-    # set it with cache_compiler_rt_library.
-    set(clang_command ${CMAKE_CXX_COMPILER} "${ARG_FLAGS}")
-    if(target)
-      list(APPEND clang_command "--target=${target}")
-    endif()
-    get_property(cxx_flags CACHE CMAKE_CXX_FLAGS PROPERTY VALUE)
-    string(REPLACE " " ";" cxx_flags "${cxx_flags}")
-    list(APPEND clang_command ${cxx_flags})
-    set(cmd_prefix "")
-    if(MSVC)
-      set(cmd_prefix "/clang:")
-    endif()
+  set(cmd_prefix "")
+  if(MSVC)
+    set(cmd_prefix "/clang:")
+  endif()
+
+  # If the C++ compiler is Clang, run it with -dumpmachine to find
+  # the target triple
+  set(target "")  
+  if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    execute_process(
+      COMMAND "${clang_command}" ${cmd_prefix}-dumpmachine
+      OUTPUT_VARIABLE target
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+    )
+  endif()
+
+  # If target is set and COMPILER_RT_LIBRARY_builtins_${target} 
+  # cache variable is not defined, then set it by invoking Clang for the target triple.
+  if(NOT ${target} STREQUAL "" AND NOT DEFINED COMPILER_RT_LIBRARY_builtins_${target})
+    list(APPEND clang_command "${cmd_prefix}--target=${target}")
     execute_process(
       COMMAND ${clang_command} "${cmd_prefix}--rtlib=compiler-rt" "${cmd_prefix}-print-libgcc-file-name"
       RESULT_VARIABLE had_error
@@ -27,20 +32,19 @@ function(find_compiler_rt_library variable)
     string(STRIP "${library_file}" library_file)
     file(TO_CMAKE_PATH "${library_file}" library_file)
     get_filename_component(basename ${library_file} NAME)
-    if(EXISTS "${library_file}" AND (basename MATCHES ".*clang_rt\.([a-z0-9_\-]+)\.(a|lib)"))
-      message(STATUS "Found compiler-rt library: ${basename}")
+    if(basename MATCHES ".*clang_rt\.([a-z0-9_\-]+)\.(a|lib)")
+      message(STATUS "Found compiler-rt builtin library: ${basename}")
       set(COMPILER_RT_LIBRARY_builtins_${target} "${basename}" CACHE INTERNAL
         "compiler-rt library for ${target}")
     else()
       message(STATUS "Failed to find compiler-rt library for ${target}")
-      set(COMPILER_RT_LIBRARY_builtins_${target} "NOTFOUND" CACHE INTERNAL
+      set(COMPILER_RT_LIBRARY_builtins_${target} "" CACHE INTERNAL
           "compiler-rt library for ${target}")
     endif()
   endif()
-
-  if(NOT COMPILER_RT_LIBRARY_builtins_${target})
-    set(${variable} "NOTFOUND" PARENT_SCOPE)
-  else()
+  if(DEFINED COMPILER_RT_LIBRARY_builtins_${target})
     set(${variable} "${COMPILER_RT_LIBRARY_builtins_${target}}" PARENT_SCOPE)
+  else()
+    set(${variable} "" PARENT_SCOPE)
   endif()
 endfunction()


### PR DESCRIPTION
This patch adds find compiler-rt libs function imported from llvm-project/cmake/modules to testsuite repository. Some tests require to link compiler-rt builtins library on windows and this function helps locate the library path from install dir.