### PR TITLE
[Fortran] Comment out tests with missing semantic checks

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -2413,6 +2413,8 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   private_type_4.f90
   private_type_9.f90
   proc_decl_4.f90
+  proc_ptr_37.f90 # https://github.com/llvm/llvm-project/issues/73215
+  proc_ptr_46.f90 # https://github.com/llvm/llvm-project/issues/73215
   protected_3.f90
   selected_char_kind_3.f90
   spread_init_expr_2.f90


### PR DESCRIPTION
These tests are looking for a semantic error that flang is not emitting but they used to pass because a TODO for procedure pointers was emitted in lowering. Lowering implemented procedure pointers, so these test now fail. I opened an issue against semantics, but I want to comment out these tests so that we can still land the lowering implementation of procedure pointers that is correct (the lowering change was reverted for now).

See https://github.com/llvm/llvm-project/issues/73215