### PR TITLE
[Fortran/gfortran] Correctly handle "shouldfail" tests

### DIFF
--- a/Fortran/gfortran/CMakeLists.txt
+++ b/Fortran/gfortran/CMakeLists.txt
@@ -540,19 +540,17 @@ function(gfortran_add_execute_test expect_error main others fflags ldflags)
   get_filename_component(working_dir_name "${working_dir}" NAME)
 
   llvm_test_executable_no_test(${target} ${main} ${others})
-  llvm_test_run(WORKDIR "%S/${working_dir_name}")
-  # FIXME: All we need is to negate the exit code. LLVM's not utility can do
-  # this, but if it is not already installed on the system, it will have to be
-  # obtained from LLVM's build directory. It is not clear that we can rely on
-  # this when running the test suite.
+
   if (WIN32)
     # Probably need to check %errorlevel% here.
     message(FATAL_ERROR "Verification not implemented on Windows.")
   else ()
     if (expect_error)
-      llvm_test_verify(${TESTCMD} $? -ne 0)
+      llvm_test_run(
+        EXECUTABLE "%b/not --crash ${target}"
+        WORKDIR "%S/${working_dir_name}")
     else ()
-      llvm_test_verify(${TESTCMD} $? -eq 0)
+      llvm_test_run(WORKDIR "%S/${working_dir_name}")
     endif ()
   endif ()
   llvm_add_test_for_target(${target})

--- a/Fortran/gfortran/CMakeLists.txt
+++ b/Fortran/gfortran/CMakeLists.txt
@@ -68,6 +68,7 @@ set(FLANG_ERRORING_FFLAGS
   -fcheck-array-temporaries
   -fcheck=bounds
   -fcheck=do
+  -fcheck=mem
   -fcheck=recursion
   -fcoarray=lib
   -fcray-pointer
@@ -540,18 +541,12 @@ function(gfortran_add_execute_test expect_error main others fflags ldflags)
   get_filename_component(working_dir_name "${working_dir}" NAME)
 
   llvm_test_executable_no_test(${target} ${main} ${others})
-
-  if (WIN32)
-    # Probably need to check %errorlevel% here.
-    message(FATAL_ERROR "Verification not implemented on Windows.")
+  if (expect_error)
+    llvm_test_run(
+      EXECUTABLE "%b/not --crash %S/${target}"
+      WORKDIR "%S/${working_dir_name}")
   else ()
-    if (expect_error)
-      llvm_test_run(
-        EXECUTABLE "%b/not --crash ${target}"
-        WORKDIR "%S/${working_dir_name}")
-    else ()
-      llvm_test_run(WORKDIR "%S/${working_dir_name}")
-    endif ()
+    llvm_test_run(WORKDIR "%S/${working_dir_name}")
   endif ()
   llvm_add_test_for_target(${target})
 

--- a/Fortran/gfortran/CMakeLists.txt
+++ b/Fortran/gfortran/CMakeLists.txt
@@ -530,8 +530,9 @@ endfunction()
 # Setup an "execute" test. In the case of multi-file tests, MAIN will be the
 # main file. For multi-file tests, OTHERS will be the remaining files needed by
 # the test. FFLAGS are additional compiler flags needed by the test. LDFLAGS
-# are the other linker flags needed by the test.
-function(gfortran_add_execute_test main others fflags ldflags)
+# are the other linker flags needed by the test. If EXPECT_ERROR evaluates to
+# true, the test is expected to fail.
+function(gfortran_add_execute_test expect_error main others fflags ldflags)
   # PREFIX_EXECUTE will have been defined in the subdirectory from which this
   # function is called.
   gfortran_unique_target_name("${PREFIX_EXECUTE}" "${main}" target)
@@ -540,6 +541,20 @@ function(gfortran_add_execute_test main others fflags ldflags)
 
   llvm_test_executable_no_test(${target} ${main} ${others})
   llvm_test_run(WORKDIR "%S/${working_dir_name}")
+  # FIXME: All we need is to negate the exit code. LLVM's not utility can do
+  # this, but if it is not already installed on the system, it will have to be
+  # obtained from LLVM's build directory. It is not clear that we can rely on
+  # this when running the test suite.
+  if (WIN32)
+    # Probably need to check %errorlevel% here.
+    message(FATAL_ERROR "Verification not implemented on Windows.")
+  else ()
+    if (expect_error)
+      llvm_test_verify(${TESTCMD} $? -ne 0)
+    else ()
+      llvm_test_verify(${TESTCMD} $? -eq 0)
+    endif ()
+  endif ()
   llvm_add_test_for_target(${target})
 
   target_include_directories(${target}
@@ -576,6 +591,9 @@ function(gfortran_add_execute_tests_from tests)
   cmake_parse_arguments(GFORTRAN "" "" "FFLAGS;LDFLAGS" ${ARGN})
 
   foreach(file ${tests})
+    # Whether this test is expected to pass or fail.
+    set(expect_error OFF)
+
     # The file containing the "run" directive will be the main file.
     set(main "")
 
@@ -611,13 +629,15 @@ function(gfortran_add_execute_tests_from tests)
         separate_arguments(file_fflags UNIX_COMMAND ${CMAKE_MATCH_2})
         list(REMOVE_ITEM file_fflags ${FLANG_ERRORING_FFLAGS})
         list(APPEND fflags ${file_fflags})
+      elseif (line MATCHES "[{][ ]*dg-shouldfail[ ]+(.*)[}]")
+        set(expect_error ON)
       endif()
     endforeach()
 
     # Since any dependent files could also be processed by this function, there
     # is no guarantee that main will have been set.
     if (main)
-      gfortran_add_execute_test(${main} "${others}" "${fflags}" "${ldflags}")
+      gfortran_add_execute_test(${expect_error} ${main} "${others}" "${fflags}" "${ldflags}")
     endif()
   endforeach()
 endfunction()
@@ -632,7 +652,7 @@ function(gfortran_add_execute_tests tests)
   list(APPEND ldflags ${GFORTRAN_LDFLAGS})
 
   foreach(file ${tests})
-    gfortran_add_execute_test(${file} "" "${fflags}" "${ldflags}")
+    gfortran_add_execute_test(OFF ${file} "" "${fflags}" "${ldflags}")
   endforeach()
 endfunction()
 

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1993,6 +1993,77 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
 
   # ---------------------------------------------------------------------------
   #
+  # These tests are expected to fail at runtime, but pass instead.
+  #
+  allocate_error_1.f90
+  bounds_check_7.f90
+  bounds_check_10.f90
+  all_bounds_1.f90
+  bounds_check_12.f90
+  bounds_check_array_ctor_1.f90
+  bounds_check_array_ctor_2.f90
+  bounds_check_array_ctor_4.f90
+  bounds_check_array_ctor_6.f90
+  bounds_check_array_ctor_7.f90
+  bounds_check_array_ctor_8.f90
+  bounds_check_fail_3.f90
+  bounds_check_fail_4.f90
+  bounds_check_strlen_1.f90
+  bounds_check_strlen_2.f90
+  bounds_check_strlen_3.f90
+  bounds_check_strlen_4.f90
+  bounds_check_strlen_5.f90
+  bounds_check_strlen_7.f90
+  char_bounds_check_fail_1.f90
+  char_pointer_assign_4.f90
+  char_pointer_assign_5.f90
+  cshift_bounds_2.f90
+  deallocate_error_1.f90
+  deallocate_error_2.f90
+  do_check_2.f90
+  do_check_3.f90
+  do_check_4.f90
+  do_check_11.f90
+  do_check_12.f90
+  endfile_4.f90
+  fmt_g0_2.f08
+  inline_sum_bounds_check_1.f90
+  inline_sum_bounds_check_2.f90
+  io_real_boz2.f90
+  io_real_boz_4.f90
+  io_real_boz_5.f90
+  matmul_bounds_2.f90
+  matmul_bounds_3.f90
+  matmul_bounds_4.f90
+  matmul_bounds_5.f90
+  matmul_bounds_8.f90
+  matmul_bounds_10.f90
+  maxloc_bounds_1.f90
+  maxloc_bounds_2.f90
+  maxloc_bounds_3.f90
+  maxloc_bounds_4.f90
+  maxloc_bounds_5.f90
+  maxloc_bounds_7.f90
+  maxloc_bounds_8.f90
+  merge_char_3.f90
+  no_unit_error_1.f90
+  pack_bounds_1.f90
+  pointer_check_10.f90
+  pointer_remapping_6.f08
+  pr96436_6.f90
+  pr96436_7.f90
+  pr96436_8.f90
+  pr96436_9.f90
+  pr96436_10.f90
+  recursive_check_9.f90
+  recursive_check_11.f90
+  recursive_check_13.f90
+  spread_bounds_1.f90
+  transpose_2.f90
+  unpack_bounds_1.f90
+
+  # ---------------------------------------------------------------------------
+  #
   # This test fails with optimizations enabled, but succeeds when compiled
   # without optimizations.
   inline_transpose_1.f90
@@ -2600,33 +2671,6 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   # _OPENMP/_OPENACC directives while gfortran does.
   openacc-define-3.f90
   openmp-define-3.f90
-
-  # Tests looking for runtime errors (e.g., bound checks). Correctly
-  # caught by flang runtime.
-  allocate_error_6.f90
-  allocate_with_source_22.f03
-  allocate_with_source_23.f03
-  all_bounds_1.f90
-  associate_32.f03
-  bounds_check_12.f90
-  bounds_check_array_ctor_4.f90
-  bounds_check_fail_3.f90
-  cshift_bounds_3.f90
-  cshift_bounds_4.f90
-  dim_sum_1.f90
-  dim_sum_2.f90
-  dim_sum_3.f90
-  inline_matmul_1.f90
-  maxloc_bounds_1.f90
-  maxloc_bounds_2.f90
-  maxloc_bounds_3.f90
-  maxloc_bounds_4.f90
-  maxloc_bounds_5.f90
-  maxloc_bounds_7.f90
-  maxloc_bounds_8.f90
-  pack_bounds_1.f90
-  ptr_func_assign_1.f08
-  spread_bounds_1.f90
 
   # Bad test, assigning an 11 elements array to a 12 elements array.
   transfer_array_intrinsic_4.f90

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -316,6 +316,8 @@ file(GLOB UNIMPLEMENTED_FILES CONFIGURE_DEPENDS
   allocate_with_source_14.f03
   allocate_with_source_17.f03
   allocate_with_source_21.f03
+  allocate_with_source_22.f03
+  allocate_with_source_23.f03
   allocate_with_source_25.f90
   allocate_with_source_8.f08
   associate_18.f08
@@ -534,6 +536,7 @@ file(GLOB UNIMPLEMENTED_FILES CONFIGURE_DEPENDS
   proc_ptr_comp_50.f90
   proc_ptr_comp_pass_3.f90
   proc_ptr_comp_pass_6.f90
+  ptr_func_assign_1.f08
   ptr_func_assign_2.f08
   ptr_func_assign_3.f08
   realloc_on_assign_20.f90
@@ -1869,6 +1872,23 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   Wall.f90 # no warning for missing & on continuation line in char constant
   Wno-all.f90 # no warning for missing & on continuation line in char constant
   bessel_7.f90 # unclear
+  bounds_check_10.f90
+  bounds_check_7.f90
+  bounds_check_array_ctor_1.f90
+  bounds_check_array_ctor_2.f90
+  bounds_check_array_ctor_6.f90
+  bounds_check_array_ctor_7.f90
+  bounds_check_array_ctor_8.f90
+  bounds_check_fail_4.f90
+  bounds_check_strlen_1.f90
+  bounds_check_strlen_2.f90
+  bounds_check_strlen_3.f90
+  bounds_check_strlen_4.f90
+  bounds_check_strlen_5.f90
+  bounds_check_strlen_7.f90
+  char_bounds_check_fail_1.f90
+  char_pointer_assign_4.f90
+  char_pointer_assign_5.f90
   check_bits_1.f90 # requires -fcheck=bits to catch ISHFTC runtime error
   check_bits_2.f90 # requires -fcheck=bits to catch ISHFTC runtime error
   internal_dummy_2.f08 # causes flang-new to crash llvm-project/issues/76927
@@ -1877,10 +1897,16 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   dollar_edit_descriptor_4.f # TODO: (i3,$) format shouldn't advance record when looping
   list_read_11.f90 # more CR character shenanigans
   matmul_5.f90
+  matmul_bounds_10.f90
   matmul_bounds_11.f90
   matmul_bounds_13.f90
   matmul_bounds_15.f
   matmul_bounds_16.f
+  matmul_bounds_2.f90
+  matmul_bounds_3.f90
+  matmul_bounds_4.f90
+  matmul_bounds_5.f90
+  matmul_bounds_8.f90
   matmul_bounds_7.f90
   matmul_bounds_9.f90
   maxloc_2.f90
@@ -1890,6 +1916,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   maxlocval_2.f90
   maxlocval_4.f90
   merge_bits_2.F90
+  merge_char_3.f90
   minloc_1.f90
   minlocval_1.f90
   minlocval_4.f90
@@ -1929,6 +1956,11 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   pr96436_3.f90
   pr96436_4.f90
   pr96436_5.f90
+  pr96436_6.f90
+  pr96436_7.f90
+  pr96436_8.f90
+  pr96436_9.f90
+  pr96436_10.f90
   promotion_3.f90
   promotion_4.f90
   promotion.f90
@@ -1960,7 +1992,10 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   real8-4.f90
   real_const_3.f90
   realloc_on_assign_11.f90
+  recursive_check_11.f90
+  recursive_check_13.f90
   recursive_check_7.f90
+  recursive_check_9.f90
   repeat_1.f90
   reshape_order_1.f90
   reshape_order_2.f90
@@ -1974,10 +2009,12 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   streamio_17.f90
   streamio_4.f90
   system_clock_3.f08
+  transpose_2.f90
   unf_io_convert_4.f90
   unf_read_corrupted_1.f90
   unf_short_record_1.f90
   unformatted_subrecord_1.f90
+  unpack_bounds_1.f90
   unpack_bounds_2.f90
   unpack_bounds_3.f90
   utf8_1.f03
@@ -1990,77 +2027,6 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   widechar_intrinsics_8.f90
   write_check.f90
   zero_sized_1.f90
-
-  # ---------------------------------------------------------------------------
-  #
-  # These tests are expected to fail at runtime, but pass instead.
-  #
-  allocate_error_1.f90
-  bounds_check_7.f90
-  bounds_check_10.f90
-  all_bounds_1.f90
-  bounds_check_12.f90
-  bounds_check_array_ctor_1.f90
-  bounds_check_array_ctor_2.f90
-  bounds_check_array_ctor_4.f90
-  bounds_check_array_ctor_6.f90
-  bounds_check_array_ctor_7.f90
-  bounds_check_array_ctor_8.f90
-  bounds_check_fail_3.f90
-  bounds_check_fail_4.f90
-  bounds_check_strlen_1.f90
-  bounds_check_strlen_2.f90
-  bounds_check_strlen_3.f90
-  bounds_check_strlen_4.f90
-  bounds_check_strlen_5.f90
-  bounds_check_strlen_7.f90
-  char_bounds_check_fail_1.f90
-  char_pointer_assign_4.f90
-  char_pointer_assign_5.f90
-  cshift_bounds_2.f90
-  deallocate_error_1.f90
-  deallocate_error_2.f90
-  do_check_2.f90
-  do_check_3.f90
-  do_check_4.f90
-  do_check_11.f90
-  do_check_12.f90
-  endfile_4.f90
-  fmt_g0_2.f08
-  inline_sum_bounds_check_1.f90
-  inline_sum_bounds_check_2.f90
-  io_real_boz2.f90
-  io_real_boz_4.f90
-  io_real_boz_5.f90
-  matmul_bounds_2.f90
-  matmul_bounds_3.f90
-  matmul_bounds_4.f90
-  matmul_bounds_5.f90
-  matmul_bounds_8.f90
-  matmul_bounds_10.f90
-  maxloc_bounds_1.f90
-  maxloc_bounds_2.f90
-  maxloc_bounds_3.f90
-  maxloc_bounds_4.f90
-  maxloc_bounds_5.f90
-  maxloc_bounds_7.f90
-  maxloc_bounds_8.f90
-  merge_char_3.f90
-  no_unit_error_1.f90
-  pack_bounds_1.f90
-  pointer_check_10.f90
-  pointer_remapping_6.f08
-  pr96436_6.f90
-  pr96436_7.f90
-  pr96436_8.f90
-  pr96436_9.f90
-  pr96436_10.f90
-  recursive_check_9.f90
-  recursive_check_11.f90
-  recursive_check_13.f90
-  spread_bounds_1.f90
-  transpose_2.f90
-  unpack_bounds_1.f90
 
   # ---------------------------------------------------------------------------
   #


### PR DESCRIPTION
The DejaGNU `shouldfail` annotation is now handled correctly. Support for tests that are expected to fail has been added to the build system for the gfortran tests. This currently does not work on Windows, but there are several other issues with building the tests on Windows anyway. 

A number of tests that were previously passing are failing as a result and those have been disabled. The failures may be a result of an actual bug in the runtime, or a case of flang behaving differently from gfortran. That will need to be investigated.