### PR TITLE
[Fortran/gfortran] Add a simple not tool to the test suite

### DIFF
--- a/Fortran/gfortran/CMakeLists.txt
+++ b/Fortran/gfortran/CMakeLists.txt
@@ -445,7 +445,7 @@ function(gfortran_add_compile_test expect_error main others fflags ldflags)
   if (expect_error)
     # Since we don't check for any particular error, we expect "some" error.
     # In that case, the compiler's diagnostic output will be non-empty.
-    llvm_test_verify(${TESTCMD} -s %S/${out})
+    llvm_test_verify(%b/not ${DIFFPROG} %S/${relpath}/${EMPTY_FILE} %S/${out})
   else ()
     llvm_test_verify(${DIFFPROG} %S/${relpath}/${EMPTY_FILE} %S/${out})
   endif ()
@@ -658,22 +658,10 @@ get_filename_component(ISO_FORTRAN_C_HEADER_DIR
 # otherwise.
 set(DIFFPROG)
 if (WIN32)
-  # Windows support has been disabled earlier anyway, but at some point, we
-  # should find a way to check if a file is non-empty on windows.
-  message(FATAL_ERROR "No way to check file size in Windows.")
   find_program(DIFFPROG
     NAMES fc.exe
     REQUIRED)
 else ()
-  # FIXME: For the moment, check if a file is not empty, by using the test
-  # command/shell built-in on *nix. But it is not clear that all systems will
-  # have this. What we really need is to invert the result of DIFFPROG. LLVM has
-  # a not utility that will do just this. But it needs LLVM's build directory
-  # to be present unless it is installed on the system already. It is not clear
-  # if we can depend on this.
-  find_program(TESTCMD
-    NAMES test
-    REQUIRED)
   find_program(DIFFPROG
     NAMES diff cmp
     REQUIRED)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -39,3 +39,5 @@ else()
   add_executable(build-timeit-target ALIAS timeit-target)
   llvm_add_host_executable(build-timeit timeit timeit.c)
 endif()
+
+add_executable(not ${CMAKE_CURRENT_SOURCE_DIR}/not.cpp)

--- a/tools/not.cpp
+++ b/tools/not.cpp
@@ -1,0 +1,106 @@
+//===- not.cpp - The 'not' testing tool -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Usage:
+//   not cmd
+//     Will return true if cmd doesn't crash and returns false.
+//   not --crash cmd
+//     Will return true if cmd crashes (e.g. for testing crash reporting).
+
+// This file is a stripped down version of not.cpp from llvm/utils. This does
+// not depend on any LLVM library.
+
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
+int main(int argc, const char **argv) {
+  bool expectCrash = false;
+
+  ++argv;
+  --argc;
+
+  if (argc > 0 && std::string(argv[0]) == "--crash") {
+    ++argv;
+    --argc;
+    expectCrash = true;
+
+    // Crash is expected, so disable crash report and symbolization to reduce
+    // output and avoid potentially slow symbolization.
+#ifdef _WIN32
+    SetEnvironmentVariableA("LLVM_DISABLE_CRASH_REPORT", "1");
+    SetEnvironmentVariableA("LLVM_DISABLE_SYMBOLIZATION", "1");
+#else
+    setenv("LLVM_DISABLE_CRASH_REPORT", "1", 0);
+    setenv("LLVM_DISABLE_SYMBOLIZATION", "1", 0);
+#endif
+  }
+
+  if (argc == 0)
+    return 1;
+
+  std::stringstream ss;
+  ss << argv[0];
+  for (int i = 1; i < argc; ++i)
+    ss << " " << argv[i];
+  std::string cmd = ss.str();
+
+  int result = std::system(cmd.c_str());
+  int retcode = 0;
+  int signal = 0;
+
+#ifdef _WIN32
+  // Handle abort() in msvcrt -- It has exit code as 3.  abort(), aka
+  // unreachable, should be recognized as a crash.  However, some binaries use
+  // exit code 3 on non-crash failure paths, so only do this if we expect a
+  // crash.
+  if (expectCrash && result == 3) {
+    retcode = 3;
+    signal = 1;
+  } else if (errno) {
+    // If the command interpreter was not found, errno will be set and 0 will
+    // be returned. It is unlikely that this will happen in our use case, but
+    // check anyway.
+    retcode = 1;
+    signal = 1;
+  } else {
+    // On Windows, result is the exit code, except for the special case above.
+    retcode = result;
+    signal = 0;
+  }
+#elif defined(WEXITSTATUS) && defined(WTERMSIG)
+  // On POSIX systems and Solaris, result is a composite value of the exit code
+  // and, potentially, the signal that caused termination of the command.
+  retcode = WEXITSTATUS(result);
+  signal = WTERMSIG(result);
+#else
+#error "Unsupported system"
+#endif
+
+  // If signal is non-zero, the command caused a crash, usually SIGABRT.
+  if (signal) {
+    if (expectCrash)
+      return EXIT_SUCCESS;
+    return EXIT_FAILURE;
+  }
+
+  // The command exited normally. If the command was expected to crash, return
+  // EXIT_FAILURE since EXIT_SUCCESS is returned in the event of an expected
+  // crash. Otherwise, invert the return code.
+  if (expectCrash)
+    return EXIT_FAILURE;
+  else if (retcode == EXIT_SUCCESS)
+    return EXIT_FAILURE;
+  else
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Add a tool very similar to LLVM's not utility which inverts the return code of a command. The major difference is that the utility is not dependent on LLVM's libraries and performs less error checking than LLVM's not. It does support the
 --crash option when the command is expected to crash.

There is a need for something similar to the `not` utility in the gfortran test suite where some tests are [expected to crash](https://github.com/llvm/llvm-test-suite/pull/57#discussion_r1420934396). However, we cannot rely on the utility being available since the LLVM build directory may not be available when running the test suite. Unless LLVM was built with `-DLLVM_INSTALL_UTILS=On`, the utilities will not be available even if clang/flang are present.

In keeping with some of the other tools in the test suite which were borrowed from LLVM, this has been stripped down and made independent of LLVM's libraries.
