### PR TITLE
Workaround build failure in ClamAV with zlib

### DIFF
--- a/MultiSource/Applications/ClamAV/CMakeLists.txt
+++ b/MultiSource/Applications/ClamAV/CMakeLists.txt
@@ -178,4 +178,9 @@ if(TARGET_OS STREQUAL "Linux")
   find_package(Intl REQUIRED)
   target_link_libraries(clamscan ${Intl_LIBRARIES})
 endif()
+# zlib fails to build with correctly defined target OS macros.
+# (https://github.com/madler/zlib/pull/895)
+# Disable the compiler extension to workaround the build failure until a zlib
+# source update with the fix.
+target_compile_options(clamscan PRIVATE -fno-define-target-os-macros)
 llvm_test_data(clamscan ${INPUT} dbdir)


### PR DESCRIPTION
zlib failed to build with a recent compiler extension (https://github.com/llvm/llvm-project/pull/74676). Workaround the build failure by disabling the extension for now.