### PR TITLE
[gcc-c-torture] use -fwrapv for 950704-1.c (signed overflow)

### DIFF
--- a/SingleSource/Regression/C/gcc-c-torture/execute/CMakeLists.txt
+++ b/SingleSource/Regression/C/gcc-c-torture/execute/CMakeLists.txt
@@ -181,6 +181,7 @@ file(GLOB TestRequiresFWrapV CONFIGURE_DEPENDS
   20040409-1.c
   20040409-2.c
   20040409-3.c
+  950704-1.c
 )
 
 # Tests that require -Wno-return-type


### PR DESCRIPTION
test fails since #76044