### PR TITLE
[tools] Fix not utility to work on iOS

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -40,12 +40,4 @@ else()
   llvm_add_host_executable(build-timeit timeit timeit.c)
 endif()
 
-# FIXME: the iOS buildbots can't build this since it uses `std::system`, but
-# since we don't support Fortram on the iOS bots and this utility is only used
-# by Fortran tests, it effectively "reverts to green", without entirely
-# reverting the patch.
-#
-# See: https://github.com/llvm/llvm-project/issues/77137
-if(TEST_SUITE_FORTRAN)
-  add_executable(not ${CMAKE_CURRENT_SOURCE_DIR}/not.cpp)
-endif()
+add_executable(not ${CMAKE_CURRENT_SOURCE_DIR}/not.cpp)

--- a/tools/not.cpp
+++ b/tools/not.cpp
@@ -17,8 +17,6 @@
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
-#include <spawn.h>
-#include <wait.h>
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
@@ -27,6 +25,8 @@
 #endif
 
 #ifdef __APPLE__
+#include <spawn.h>
+#include <wait.h>
 #include <TargetConditionals.h>
 #endif
 
@@ -64,9 +64,8 @@ int main(int argc, char* const* argv) {
   std::string cmd = ss.str();
   result = std::system(cmd.c_str());
 #else
-  char* const* environ = NULL;
   pid_t pid;
-  if (posix_spawn(&pid, argv[0], NULL, NULL, argv, environ))
+  if (posix_spawn(&pid, argv[0], NULL, NULL, argv, NULL))
     return EXIT_FAILURE;
   if (waitpid(pid, &result, WUNTRACED | WCONTINUED) == -1)
     return EXIT_FAILURE;

--- a/tools/not.cpp
+++ b/tools/not.cpp
@@ -26,7 +26,7 @@
 
 #ifdef __APPLE__
 #include <spawn.h>
-#include <wait.h>
+#include <sys/wait.h>
 #include <TargetConditionals.h>
 #endif
 


### PR DESCRIPTION
This addresses issue #77137 (std::system is not available on iOS). The implementation uses posix_spawn on iOS but std::system elsewhere.

This has only been tested on Linux on X86 and an older AArch64. 

@jroelofs, could you try this on an iOS and let me know if it works there? 