### PR TITLE
[test-suite][Fortran] Ignore -fstrict-aliasing and -fschedule-insns

### DIFF
--- a/Fortran/gfortran/CMakeLists.txt
+++ b/Fortran/gfortran/CMakeLists.txt
@@ -146,8 +146,10 @@ set(FLANG_ERRORING_FFLAGS
   -fpeel-loops
   -frecursive
   -fsanitize=undefined
+  -fschedule-insns
   -fset-g77-defaults
   -fshort-enums
+  -fstrict-aliasing
   -ftest-forall-temp
   -ftree-loop-distribution
   -ftree-loop-vectorize

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1815,9 +1815,6 @@ file(GLOB SKIPPED_FILES CONFIGURE_DEPENDS
   pr93524.f90
   public_private_module_3.f90
   static_linking_1.f
-
-  # error: unknown argument" due to '-fschedule-insns' and '-fstrict-aliasing'.
-  pr43808.f90
 )
 
 # These tests are disabled because they fail when they are expected to pass.


### PR DESCRIPTION
Ignore these flags as they are currently not supported by flang.
Also re-enable pr43808.f90 test, that passes with this change.
