### PR TITLE
[flang] Disable some tests whose errors are now warnings

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -2213,6 +2213,23 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   whole_file_1.f90
   whole_file_2.f90
 
+  # Tests that used to be hard errors, are now warnings, need -pedantic to
+  # observe them
+  generic_32.f90
+  generic_34.f90
+  generic_7.f90
+  interface_37.f90
+  interface_6.f90
+  pr77406.f90
+  pr95584.f90
+  typebound_generic_10.f03
+  typebound_generic_11.f90
+  typebound_generic_12.f03
+  typebound_generic_13.f03
+  typebound_operator_14.f90
+  typebound_operator_16.f03
+  deallocate_error_2.f90
+
   # Tests that would be errors if we supported options to enable checks
   dec_structure_24.f90
   dec_structure_26.f90

--- a/Fortran/gfortran/regression/c-interop/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/c-interop/DisabledFiles.cmake
@@ -144,4 +144,8 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   # These files are expected to fail to compile, but succeed instead.
   c516.f90
   c524a.f90
+
+  # Tests that used to be hard errors, are now warnings, need -pedantic to
+  # observe them
+  tkr.f90
 )


### PR DESCRIPTION
Recent changes to generic interface analysis have reduced a previous hard error message to an optional warning.  These tests must be run with -pedantic -Werror to cause compilation to fail.  Until I can figure out how to make that happen, disable those tests so that build bots don't fail.