### PR TITLE
[Fortran] Enable tests that failed when using libpgmath on AArch64 Linux

### DIFF
--- a/Fortran/UnitTests/fcvs21_f95/CMakeLists.txt
+++ b/Fortran/UnitTests/fcvs21_f95/CMakeLists.txt
@@ -79,11 +79,10 @@ else()
   list(FILTER Source EXCLUDE REGEX "FM509\.f$")
 endif()
 
-# Skip some tests that currently fail with flang on AArch64 when using libpgmath.
+# Skip some tests that currently fail with flang on Windows when using libpgmath.
 # FIXME: Reenable these tests after libpgmath is fixed or after we no longer
 # depend on it.
-if (CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang"
-    AND (ARCH STREQUAL "AArch64" OR TARGET_OS STREQUAL "Windows"))
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang" AND TARGET_OS STREQUAL "Windows")
   # Regex because the GLOB returns the full path to each file
   list(FILTER Source EXCLUDE REGEX "FM813\.f$")
   list(FILTER Source EXCLUDE REGEX "FM815\.f$")


### PR DESCRIPTION
Now that we're not using libpgmath, these tests pass on AArch64.

They may work on Windows now but I don't have a build setup to check yet, and none of the builders run the test suite yet. If/when I can confirm, I'll come back and remove the Windows check too.