### PR TITLE
utils/compare.py: Fix syntax warning on python 3.12

### DIFF
--- a/utils/compare.py
+++ b/utils/compare.py
@@ -192,7 +192,7 @@ def print_filter_stats(reason, before, after):
 # in the middle
 def truncate(string, prefix_len, suffix_len):
     return re.sub(
-        "^(.{%d}).*(.{%d})$" % (prefix_len, suffix_len), "\g<1>...\g<2>", string
+        "^(.{%d}).*(.{%d})$" % (prefix_len, suffix_len), r"\g<1>...\g<2>", string
     )
 
 


### PR DESCRIPTION
As of Python 3.12 there's now a syntax warning for invalid escape sequences:

    ./utils/compare.py:195: SyntaxWarning: invalid escape sequence '\g'

This fixes it by using a raw string literal, as recommended here:
https://docs.python.org/3/library/re.html
