### PR TITLE
[Fortran/gfortran] Switch to using the static test configuration files

### DIFF
--- a/Fortran/gfortran/CMakeLists.txt
+++ b/Fortran/gfortran/CMakeLists.txt
@@ -453,28 +453,55 @@ set(FLANG_ERRORING_FFLAGS
   --param
 )
 
-# Find all the Fortran files in the current source directory that may be test
-# files. This will filter out those files that have been explicitly disabled
-# for any reason. The returned files will be consist of the main file for
-# "execute" and "compile" tests as well as any dependencies for multi-file
-# tests.
-function(gfortran_find_test_files unsupported unimplemented skipped failing out)
-  # This will just get all the Fortran source files in the directory. Since
-  # the tests may be a mix of single-source and multi-source tests, this will
-  # include files that are dependencies of some "main" test file as well.
-  file(GLOB files CONFIGURE_DEPENDS LIST_DIRECTORIES false
-    *.f*
-    *.F*
-  )
+# Determine disabled tests for this directory and return them via the OUT
+# parameter.
+function(gfortran_populate_disabled_tests out)
+  set(unsupported "")
+  set(unimplemented "")
+  set(skipped "")
+  set(failing "")
 
-  set(ignore "")
+  # This will provide the lists of unsupported, unimplemented, skipped and
+  # failing files.
+  include(${CMAKE_CURRENT_SOURCE_DIR}/DisabledFiles.cmake)
+
+  list(APPEND unsupported ${UNSUPPORTED_FILES})
+  list(APPEND unimplemented ${UNIMPLEMENTED_FILES})
+  list(APPEND skipped ${SKIPPED_FILES})
+  list(APPEND failing ${FAILING_FILES})
+
+  # do the same for any requested feature extentions
+  foreach(feature ${TEST_SUITE_FORTRAN_FEATURES})
+    set(UNSUPPORTED_FILES "")
+    set(UNIMPLEMENTED_FILES "")
+    set(SKIPPED_FILES "")
+    set(FAILING_FILES "")
+    include(${CMAKE_CURRENT_SOURCE_DIR}/DisabledFiles${feature}.cmake)
+    list(APPEND unsupported ${UNSUPPORTED_FILES})
+    list(APPEND unimplemented ${UNIMPLEMENTED_FILES})
+    list(APPEND skipped ${SKIPPED_FILES})
+    list(APPEND failing ${FAILING_FILES})
+
+    # enable any tests that now pass for this feature
+    set(SUPPORTED_FILES "")
+    set(IMPLEMENTED_FILES "")
+    set(UNSKIPPED_FILES "")
+    set(PASSING_FILES "")
+    include(${CMAKE_CURRENT_SOURCE_DIR}/EnabledFiles${feature}.cmake)
+    list(REMOVE_ITEM unsupported ${SUPPORTED_FILES})
+    list(REMOVE_ITEM unimplemented ${IMPLEMENTED_FILES})
+    list(REMOVE_ITEM skipped ${UNSKIPPED_FILES})
+    list(REMOVE_ITEM failing ${PASSING_FILES})
+  endforeach()
+
+  set(disabled "")
 
   # There is still a chance that some of the unsupported tests may need to be
   # enabled, for instance if the non-standard extensions that they exercise are
   # supported due to user demand.
   if (NOT TEST_SUITE_FORTRAN_FORCE_ALL_TESTS AND
       NOT TEST_SUITE_FORTRAN_FORCE_UNSUPPORTED_TESTS)
-    list(APPEND ignore ${unsupported})
+    list(APPEND disabled ${unsupported})
   endif()
 
   # For the remaining tests, there is cause to build and run the skipped, failing
@@ -484,78 +511,72 @@ function(gfortran_find_test_files unsupported unimplemented skipped failing out)
   # become redundant and removed.
   if (NOT TEST_SUITE_FORTRAN_FORCE_ALL_TESTS AND
       NOT TEST_SUITE_FORTRAN_FORCE_UNIMPLEMENTED_TESTS)
-    list(APPEND ignore ${unimplemented})
+    list(APPEND disabled ${unimplemented})
   endif()
 
   if (NOT TEST_SUITE_FORTRAN_FORCE_ALL_TESTS AND
       NOT TEST_SUITE_FORTRAN_FORCE_SKIPPED_TESTS)
-    list(APPEND ignore ${skipped})
+    list(APPEND disabled ${skipped})
   endif()
 
   if (NOT TEST_SUITE_FORTRAN_FORCE_ALL_TESTS AND
       NOT TEST_SUITE_FORTRAN_FORCE_FAILING_TESTS)
-    list(APPEND ignore ${failing})
+    list(APPEND disabled ${failing})
   endif()
 
-  foreach(file ${ignore})
-    list(REMOVE_ITEM files ${file})
-  endforeach()
-
-  set(${out} ${files} PARENT_SCOPE)
+  set(${out} ${disabled} PARENT_SCOPE)
 endfunction()
 
-# Populate the tests from the files in the subdirectory. This macro will be
-# called from each subdirectory containing tests. It is expected that the
-# subdirectory will contain a file named "DisabledFiles.cmake" which will
-# provide the list of files that are disabled in that subdirectory for various
-# reasons. A list named TESTS is expected to be in scope before this macro is
-# called.
-macro(gfortran_populate_tests TESTS)
-  string(REPLACE "${CMAKE_SOURCE_DIR}/" "" DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-  message(STATUS "Adding directory ${DIR}")
+# Check the test configuration to make sure that it is not out of date.
+# USED_FORT is the list of Fortran files that are used in the tests. USED_OTHER
+# is the list of non-Fortran files that are used. This is intended be a sanity
+# check in case the test suite is updated without updating the static test
+# configuration. In particular, we want to catch situations where failing to
+# update the test configuration results in the new new tests being skipped
+# silently.
+function(gfortran_check_test_config used_fort used_other)
+  list(SORT used_fort)
+  list(REMOVE_DUPLICATES used_fort)
 
-  set(UNSUPPORTED "")
-  set(UNIMPLEMENTED "")
-  set(SKIPPED "")
-  set(FAILING "")
+  list(SORT used_other)
+  list(REMOVE_DUPLICATES used_other)
 
-  # This will provide the lists of unsupported, unimplemented, skipped and
-  # failing files.
-  include(${CMAKE_CURRENT_SOURCE_DIR}/DisabledFiles.cmake)
+  # All the Fortran files in the current directory.
+  file(GLOB files CONFIGURE_DEPENDS LIST_DIRECTORIES false
+    *.f*
+    *.F*
+  )
+  list(SORT files)
 
-  list(APPEND UNSUPPORTED ${UNSUPPORTED_FILES})
-  list(APPEND UNIMPLEMENTED ${UNIMPLEMENTED_FILES})
-  list(APPEND SKIPPED ${SKIPPED_FILES})
-  list(APPEND FAILING ${FAILING_FILES})
+  set(msg_unused "File not used in any test configuration")
+  set(msg_missing "File used in test configuration not found")
+  set(msg_rerun "You may need to run utils/update-test-config.py")
 
-  # do the same for any requested feature extentions
-  foreach(feature ${TEST_SUITE_FORTRAN_FEATURES})
-    set(UNSUPPORTED_FILES "")
-    set(UNIMPLEMENTED_FILES "")
-    set(SKIPPED_FILES "")
-    set(FAILING_FILES "")
-    include(${CMAKE_CURRENT_SOURCE_DIR}/DisabledFiles${feature}.cmake)
-    list(APPEND UNSUPPORTED ${UNSUPPORTED_FILES})
-    list(APPEND UNIMPLEMENTED ${UNIMPLEMENTED_FILES})
-    list(APPEND SKIPPED ${SKIPPED_FILES})
-    list(APPEND FAILING ${FAILING_FILES})
+  # Now that files and used_fort are both sorted and without any duplicates,
+  # they should be identical. If they are not, it suggests that some Fortran
+  # files have been added or removed.
+  foreach (f u IN ZIP_LISTS files used_fort)
+    if (NOT f STREQUAL u)
+      list(FIND used ${f} idx)
+      if (idx EQUAL -1)
+        message(FATAL_ERROR "${msg_unused}\n  ${f}\n${msg_rerun}\n")
+      else ()
+        message(FATAL_ERROR "${msg_missing}\n  ${u}\n${msg_rerun}\n")
+      endif ()
+    endif ()
+  endforeach ()
 
-    # enable any tests that now pass for this feature
-    set(SUPPORTED_FILES "")
-    set(IMPLEMENTED_FILES "")
-    set(UNSKIPPED_FILES "")
-    set(PASSING_FILES "")
-    include(${CMAKE_CURRENT_SOURCE_DIR}/EnabledFiles${feature}.cmake)
-    list(REMOVE_ITEM UNSUPPORTED ${SUPPORTED_FILES})
-    list(REMOVE_ITEM UNIMPLEMENTED ${IMPLEMENTED_FILES})
-    list(REMOVE_ITEM SKIPPED ${UNSKIPPED_FILES})
-    list(REMOVE_ITEM FAILING ${PASSING_FILES})
+  # It is highly likely that any non-Fortran files will be dependents of tests.
+  # They are most likely to be .c files, but we cannot guarantee that. Just
+  # check if the files in the test configuration exist. If any dependent files
+  # are added and they are missing from the test configuration, it will most
+  # likely result in a build-time error, so it won't pass by silently.
+  foreach (f ${used_other})
+    if (NOT EXISTS ${f})
+      message(FATAL_ERROR "${msg_missing}\n  ${f}\n${msg_rerun}\n")
+    endif ()
   endforeach()
-
-  # The TESTS variable is expected to be set before the macro is called.
-  gfortran_find_test_files(
-    "${UNSUPPORTED}" "${UNIMPLEMENTED}" "${SKIPPED}" "${FAILING}" "${TESTS}")
-endmacro()
+endfunction()
 
 # Generate a unique target name from the given base and prepend it with the
 # given prefix.
@@ -636,7 +657,7 @@ function(gfortran_add_compile_test expect_error main others fflags ldflags)
 
   # Add the CMake-wide environment variable CMAKE_Fortran_FLAGS
   # CMake escapes spaces. To really get a space (between arguments) use a ;
-  string(REPLACE " " ";" fflags ${fflags} ";" ${CMAKE_Fortran_FLAGS})
+  string(REPLACE " " ";" fflags "${fflags};${CMAKE_Fortran_FLAGS}")
 
   add_custom_command(
     OUTPUT ${out}
@@ -683,85 +704,12 @@ function(gfortran_add_compile_test expect_error main others fflags ldflags)
   llvm_add_test(${target}.test %S/${relpath}/${DUMMY_EXE})
 endfunction()
 
-# Look for "compile" tests in TESTS and create a test for each "main" file that
-# is found.
-function(gfortran_add_compile_tests_from tests)
-  cmake_parse_arguments(GFORTRAN "" "" "FFLAGS;LDFLAGS" ${ARGN})
-
-  foreach (file ${tests})
-    # Whether this test is expected to pass or fail.
-    set(expect_error OFF)
-
-    # For multi-file tests, these are the other files needed. For the "compile"
-    # tests, there don't seem to be any multi-file tests at the time of writing,
-    # but leave it general in case that ever changes.
-    set(others "")
-
-    set(fflags "")
-    set(ldflags "")
-    list(APPEND fflags ${GFORTRAN_FFLAGS})
-    list(APPEND ldflags ${GFORTRAN_LDFLAGS})
-
-    file(STRINGS ${file} lines)
-    foreach (line ${lines})
-      # The "compile" tests have a { dg-do compile } directive.
-      if (line MATCHES "^.*[{][ ]*dg-do[ ]*compile(.*)[}].*$")
-        # TODO: We completely ignore any target directives that may be attached
-        # to the run directives. For now, it seems to be ok, but as these tests
-        # are enabled on more platforms, the target directives might need to be
-        # handled.
-      elseif (line MATCHES "dg-additional-sources[ ]*[\"]?(.+)[\"]?[ ]*[}]")
-        separate_arguments(others UNIX_COMMAND ${CMAKE_MATCH_1})
-        list(TRANSFORM others STRIP)
-      elseif (LINE MATCHES "dg-(additional-)?options [{]?[ ]*\"([^\"]*)\"[ ]*[}]?(.*)")
-        # TODO: We completely ignore any target directives that may be attached
-        # to the run directives. For now, it seems to be ok, but as these tests
-        # are enabled on more platforms, the target directives might need to be
-        # handled.
-        separate_arguments(file_fflags UNIX_COMMAND ${CMAKE_MATCH_2})
-        list(REMOVE_ITEM file_fflags ${FLANG_ERRORING_FFLAGS})
-        list(APPEND fflags ${file_fflags})
-      elseif (line MATCHES "[{][ ]*dg-error[ ]*")
-        # Currently, we don't try to match gfortran's expected errors with
-        # flang's expected error messages. Instead, if gfortran expects an
-        # error, we test that flang produces "some" error.
-        # TODO: It may be more useful to match gfortran's error messages to
-        # flang's in which case we should do something more sophisticated here,
-        # but as a first pass, the more basic approach should do.
-        set(expect_error ON)
-      endif()
-    endforeach()
-
-    # Some files look like they ought to be "compile" tests but they don't
-    # contain a DejaGNU compile directive. Some have an error or other
-    # directive that could be used to infer that they are actually compile tests
-    # but for those that are intended to succeed, there may be no directives
-    # at all. So just treat all files as if they were "compile" tests (even
-    # those that are the main files of execute tests and ones that are
-    # dependencies in multi-file tests).
-    gfortran_add_compile_test(${expect_error} ${file} "${others}" "${fflags}" "${ldflags}")
-  endforeach()
-endfunction()
-
-# Creates a "compile" test from each file in TESTS. It is assumed that the
-# compilation is intended to succeed. Any compile/link flags that the test needs
-# must be passed explicitly.
-function(gfortran_add_compile_tests tests)
-  cmake_parse_arguments(GFORTRAN "" "" "FFLAGS;LDFLAGS" ${ARGN})
-
-  list(APPEND fflags ${GFORTRAN_FFLAGS})
-  list(APPEND ldflags ${GFORTRAN_LDFLAGS})
-
-  foreach (file ${tests})
-    gfortran_add_compile_test(OFF ${file} "" "${fflags}" "${ldflags}")
-  endforeach()
-endfunction()
-
 # Setup an "execute" test. In the case of multi-file tests, MAIN will be the
 # main file. For multi-file tests, OTHERS will be the remaining files needed by
 # the test. FFLAGS are additional compiler flags needed by the test. LDFLAGS
-# are the other linker flags needed by the test.
-function(gfortran_add_execute_test main others fflags ldflags)
+# are the other linker flags needed by the test. If EXPECT_ERROR evaluates to
+# true, the test is expected to fail.
+function(gfortran_add_execute_test expect_error main others fflags ldflags)
   # PREFIX_EXECUTE will have been defined in the subdirectory from which this
   # function is called.
   gfortran_unique_target_name("${PREFIX_EXECUTE}" "${main}" target)
@@ -769,7 +717,13 @@ function(gfortran_add_execute_test main others fflags ldflags)
   get_filename_component(working_dir_name "${working_dir}" NAME)
 
   llvm_test_executable_no_test(${target} ${main} ${others})
-  llvm_test_run(WORKDIR "%S/${working_dir_name}")
+  if (expect_error)
+    llvm_test_run(
+      EXECUTABLE "%b/not --crash %S/${target}"
+      WORKDIR "%S/${working_dir_name}")
+  else ()
+    llvm_test_run(WORKDIR "%S/${working_dir_name}")
+  endif ()
   llvm_add_test_for_target(${target})
 
   target_include_directories(${target}
@@ -798,72 +752,148 @@ function(gfortran_add_execute_test main others fflags ldflags)
   set_target_properties(${target} PROPERTIES LINKER_LANGUAGE Fortran)
 endfunction()
 
-# Look for "execute" tests in TESTS and create a test for each "main" file that
-# is found. In the case of multi-file tests, other files may be needed for the
-# test. Those will be obtained by parsing the DejaGNU directives in the "main"
-# file.
-function(gfortran_add_execute_tests_from tests)
+# The main entry point to populate the tests in the current source directory.
+# This parses the static test configuration file, filters out the disabled
+# tests, sets up the tests and performs some sanity checks. The keyword FFLAGS
+# and LDFLAGS arguments can be used to force specific compile-time and link-time
+# flags to be used when building the tests.
+function(gfortran_populate_tests)
   cmake_parse_arguments(GFORTRAN "" "" "FFLAGS;LDFLAGS" ${ARGN})
 
-  foreach(file ${tests})
-    # The file containing the "run" directive will be the main file.
-    set(main "")
+  # These are used to collect the list of source files that are used in at
+  # least one test. This is used as a sanity check to ensure that all the
+  # source files are accounted for. This is necessary to alert the user in case
+  # the tests were updated by upstream gfortran but the static test
+  # configuration was not re-generated.
+  set(used_fort)
+  set(used_other)
 
-    # For multi-file tests, these are the other files needed.
-    set(others "")
+  string(REPLACE "${CMAKE_SOURCE_DIR}/" "" pwd "${CMAKE_CURRENT_SOURCE_DIR}")
+  message(STATUS "Adding directory ${pwd}")
 
-    # Any flags needed to compile the test. These will be flang-specific flags.
-    # Directives in the test files may specify additional flags needed by the
-    # test. Those will be parsed in gfortran_add_execute_test.
-    set(fflags "")
-    set(ldflags "")
-    list(APPEND fflags ${GFORTRAN_FFLAGS})
-    list(APPEND ldflags ${GFORTRAN_LDFLAGS})
+  # The target triple is roughly of the form ${arch}-${vendor}-${sys}. Cmake
+  # has no concept of a vendor, so we set it to "unknown". The targets
+  # specification in the tests generally ignores the vendor and only matches
+  # against either the architecture or the system, so this is ok.
+  string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" arch)
+  string(TOLOWER "${CMAKE_SYSTEM_NAME}" sys)
+  set(triple "${arch}-unknown-${sys}")
 
-    file(STRINGS ${file} lines)
-    foreach (line ${lines})
-      # The "execute" tests have a { dg-do run }, or a { dg-lto-do run }
-      # directive.
-      if (line MATCHES "^.*[{][ ]*dg-(lto-)?do[ ]*run (.*)[}]$")
-        # TODO: We completely ignore any target directives that may be attached
-        # to the run directives. For now, it seems to be ok, but as these tests
-        # are enabled on more platforms, the target directives might need to be
-        # handled.
-        set(main "${file}")
-      elseif (line MATCHES "dg-additional-sources[ ]*[\"]?(.+)[\"]?[ ]*[}]")
-        separate_arguments(others UNIX_COMMAND ${CMAKE_MATCH_1})
-        list(TRANSFORM others STRIP)
-      elseif (line MATCHES "dg-(additional-)?options [{]?[ ]*\"([^\"]*)\"[ ]*[}]?(.*)")
-        # TODO: We completely ignore any target-specific options that may be
-        # present. These are usually in the form of target directives. For now,
-        # it seems to be ok, but as these tests are enabled on more platforms,
-        # target directives might need to be handled.
-        separate_arguments(file_fflags UNIX_COMMAND ${CMAKE_MATCH_2})
-        list(REMOVE_ITEM file_fflags ${FLANG_ERRORING_FFLAGS})
-        list(APPEND fflags ${file_fflags})
-      endif()
+  set(disabled)
+  gfortran_populate_disabled_tests(disabled)
+
+  file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/tests.cmake lines)
+  foreach (line ${lines})
+    # Skip comment lines where the first non-whitespace character is a #.
+    if (line MATCHES "^[ ]*#")
+      continue()
+    endif()
+
+    list(GET line 1 sources_t)
+    string(REPLACE " " ";" sources "${sources_t}")
+    list(TRANSFORM sources PREPEND ${CMAKE_CURRENT_SOURCE_DIR}/)
+
+    # The tests in the configuration must be added to the used list even if the
+    # test is disabled because the sanity check will expect that the list of
+    # Fortran files in the directory exactly matches the list of used Fortran
+    # files.
+    set(rest)
+    list(LENGTH sources nsources)
+    math(EXPR iend "${nsources} - 1")
+    foreach (i RANGE ${iend})
+      list(GET sources ${i} source)
+      if (source MATCHES "^.+[.][Ff].*$")
+        list(APPEND used_fort ${source})
+      else ()
+        list(APPEND used_other ${source})
+      endif ()
+      if (${i} GREATER 0)
+        list(APPEND rest ${source})
+      endif ()
     endforeach()
 
-    # Since any dependent files could also be processed by this function, there
-    # is no guarantee that main will have been set.
-    if (main)
-      gfortran_add_execute_test(${main} "${others}" "${fflags}" "${ldflags}")
+    # If the test is only allowed to run on certain targets, process those.
+    list(GET line 4 incl_t)
+    if (incl_t)
+      # If there are any explicit include targets, then we should assume that
+      # we cannot run the test on the current platform unless there is at
+      # least one match.
+      set(exclude ON)
+      string(REPLACE " " ";" includes ${incl_t})
+      foreach (incl ${includes})
+        string(REGEX MATCH ${incl} m ${triple})
+        if (m)
+          set(exclude OFF)
+        endif ()
+      endforeach()
+
+      # The current platform was not matched, so we should not run the test.
+      if (exclude)
+        continue()
+      endif ()
+    endif ()
+
+    # If the test is explicitly disabled on certain targets, process those.
+    list(GET line 5 excl_t)
+    if (excl_t)
+      # If there are any targets to explicitly exclude, then we should assume
+      # that we can run the test on this platform unless there is at least
+      # one match.
+      set(exclude OFF)
+      string(REPLACE " " ";" excludes ${excl_t})
+      foreach (excl ${excludes})
+        string(REGEX MATCH ${excl} m ${triple})
+        if (m)
+          set(exclude ON)
+        endif ()
+      endforeach ()
+
+      # The current platform was matched, so we should not run the test.
+      if (exclude)
+        continue ()
+      endif()
+    endif ()
+
+    # Only the main file will be in the list of disabled tests. If it is, move
+    # on to the next test in the configuration.
+    list(GET sources 0 main)
+    list(FIND disabled ${main} i)
+    if (NOT i EQUAL -1)
+      continue ()
+    endif()
+
+    # The test was not excluded and not disabled. Now we can process the other
+    # parameters and set up the test.
+    set(xfail OFF)
+    list(GET line 2 xfail_t)
+    if (xfail_t STREQUAL "xfail")
+      set(xfail ON)
+    endif ()
+
+    set(fflags)
+    list(GET line 3 options_t)
+    string(REPLACE " " ";" file_fflags "${options_t}")
+    list(REMOVE_ITEM file_fflags ${FLANG_ERRORING_FFLAGS})
+    list(APPEND fflags ${GFORTRAN_FFLAGS})
+    list(APPEND fflags ${file_fflags})
+
+    set(ldflags)
+    list(APPEND ldflags ${GFORTRAN_LDFLAGS})
+
+    list(GET line 0 kind)
+    if (kind STREQUAL "run")
+      gfortran_add_execute_test(${xfail} ${main} "${rest}" "${fflags}" "${ldflags}")
+    else()
+      # FIXME: For now, we treat all non-execute tests as compile tests, but we
+      # probably should do something more sensible for the "preprocess",
+      # "assemble", and "link" tests.
+      gfortran_add_compile_test(${xfail} ${main} "${rest}" "${fflags}" "${ldflags}")
     endif()
   endforeach()
-endfunction()
 
-# Creates an "execute" test from each file in TESTS. The tests are assumed to
-# not contain any additional DejaGNU directives. Any compiler/linker flags
-# needed by the test must be passed explicitly.
-function(gfortran_add_execute_tests tests)
-  cmake_parse_arguments(GFORTRAN "" "" "FFLAGS;LDFLAGS" ${ARGN})
-
-  list(APPEND fflags ${GFORTRAN_FFLAGS})
-  list(APPEND ldflags ${GFORTRAN_LDFLAGS})
-
-  foreach(file ${tests})
-    gfortran_add_execute_test(${file} "" "${fflags}" "${ldflags}")
-  endforeach()
+  # It would be nice to do the sanity check early, but that would complicate
+  # this code since cmake is not the nicest programming language.
+  gfortran_check_test_config("${used_fort}" "${used_other}")
 endfunction()
 
 set(HEADER_SEARCH_PATH "${TEST_SUITE_FORTRAN_ISO_C_HEADER_DIR}")

--- a/Fortran/gfortran/regression/CMakeLists.txt
+++ b/Fortran/gfortran/regression/CMakeLists.txt
@@ -11,10 +11,7 @@
 set(PREFIX_EXECUTE "gfortran-regression-execute")
 set(PREFIX_COMPILE "gfortran-regression-compile")
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_execute_tests_from("${TESTS}")
-gfortran_add_compile_tests_from("${TESTS}")
+gfortran_populate_tests()
 
 add_subdirectory(analyzer)
 add_subdirectory(asan)

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1791,6 +1791,30 @@ file(GLOB SKIPPED_FILES CONFIGURE_DEPENDS
   pr93524.f90
   public_private_module_3.f90
   static_linking_1.f
+
+  # ----------------------------------------------------------------------------
+  #
+  # These files are only intended to be run on AArch64, but we don't currently
+  # process the target attribute, so these are disabled everywhere. When the
+  # DejaGNU target attribute is handled correctly, these should be removed from
+  # here.
+  pr101158.f90
+  pr88833.f90
+  pr98974.F90
+
+  # ----------------------------------------------------------------------------
+  #
+  # These tests have a -J flag but the build system adds a -J of its own and
+  # exactly one is allowed. If the build system is changed, these can be removed
+  # from here.
+  include_14.f90
+  include_15.f90
+  include_16.f90
+  include_17.f90
+  include_18.f90
+  include_19.f90
+  include_20.f90
+  include_8.f90
 )
 
 # These tests are disabled because they fail when they are expected to pass.
@@ -1820,6 +1844,23 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   Wall.f90 # no warning for missing & on continuation line in char constant
   Wno-all.f90 # no warning for missing & on continuation line in char constant
   bessel_7.f90 # unclear
+  bounds_check_10.f90
+  bounds_check_7.f90
+  bounds_check_array_ctor_1.f90
+  bounds_check_array_ctor_2.f90
+  bounds_check_array_ctor_6.f90
+  bounds_check_array_ctor_7.f90
+  bounds_check_array_ctor_8.f90
+  bounds_check_fail_4.f90
+  bounds_check_strlen_1.f90
+  bounds_check_strlen_2.f90
+  bounds_check_strlen_3.f90
+  bounds_check_strlen_4.f90
+  bounds_check_strlen_5.f90
+  bounds_check_strlen_7.f90
+  char_bounds_check_fail_1.f90
+  char_pointer_assign_4.f90
+  char_pointer_assign_5.f90
   check_bits_1.f90 # requires -fcheck=bits to catch ISHFTC runtime error
   check_bits_2.f90 # requires -fcheck=bits to catch ISHFTC runtime error
   internal_dummy_2.f08 # causes flang-new to crash llvm-project/issues/76927
@@ -1828,10 +1869,16 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   dollar_edit_descriptor_4.f # TODO: (i3,$) format shouldn't advance record when looping
   list_read_11.f90 # more CR character shenanigans
   matmul_5.f90
+  matmul_bounds_10.f90
   matmul_bounds_11.f90
   matmul_bounds_13.f90
   matmul_bounds_15.f
   matmul_bounds_16.f
+  matmul_bounds_2.f90
+  matmul_bounds_3.f90
+  matmul_bounds_4.f90
+  matmul_bounds_5.f90
+  matmul_bounds_8.f90
   matmul_bounds_7.f90
   matmul_bounds_9.f90
   maxloc_2.f90
@@ -1841,6 +1888,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   maxlocval_2.f90
   maxlocval_4.f90
   merge_bits_2.F90
+  merge_char_3.f90
   minloc_1.f90
   minlocval_1.f90
   minlocval_4.f90
@@ -1880,6 +1928,11 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   pr96436_3.f90
   pr96436_4.f90
   pr96436_5.f90
+  pr96436_6.f90
+  pr96436_7.f90
+  pr96436_8.f90
+  pr96436_9.f90
+  pr96436_10.f90
   promotion_3.f90
   promotion_4.f90
   promotion.f90
@@ -1911,7 +1964,10 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   real8-4.f90
   real_const_3.f90
   realloc_on_assign_11.f90
+  recursive_check_11.f90
+  recursive_check_13.f90
   recursive_check_7.f90
+  recursive_check_9.f90
   repeat_1.f90
   reshape_order_1.f90
   reshape_order_2.f90
@@ -1925,10 +1981,12 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   streamio_17.f90
   streamio_4.f90
   system_clock_3.f08
+  transpose_2.f90
   unf_io_convert_4.f90
   unf_read_corrupted_1.f90
   unf_short_record_1.f90
   unformatted_subrecord_1.f90
+  unpack_bounds_1.f90
   unpack_bounds_2.f90
   unpack_bounds_3.f90
   utf8_1.f03
@@ -1956,7 +2014,34 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
 
   # ---------------------------------------------------------------------------
   #
+  # These tests are expected to raise a runtime error, but currently don't.
+
+  allocate_error_1.f90
+  cshift_bounds_2.f90
+  deallocate_error_1.f90
+  deallocate_error_2.f90
+  do_check_2.f90
+  do_check_3.f90
+  do_check_4.f90
+  do_check_11.f90
+  do_check_12.f90
+  endfile_4.f90
+  fmt_g0_2.f08
+  inline_sum_bounds_check_1.f90
+  inline_sum_bounds_check_2.f90
+  io_real_boz2.f90
+  io_real_boz_4.f90
+  io_real_boz_5.f90
+  no_unit_error_1.f90
+  pointer_check_10.f90
+  pointer_remapping_6.f08
+
+  # ---------------------------------------------------------------------------
+  #
   # Compilation of these tests is expected to fail, but it succeeds instead.
+
+  binding_label_tests_26b.f90
+  test_common_binding_labels_2_main.f03
 
   # Tests that exercise gfortran's ability to set -std=f95 and then see errors on newer features
   abstract_type_1.f90

--- a/Fortran/gfortran/regression/analyzer/CMakeLists.txt
+++ b/Fortran/gfortran/regression/analyzer/CMakeLists.txt
@@ -6,7 +6,4 @@
 #
 #===------------------------------------------------------------------------===#
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_execute_tests_from("${TESTS}")
-gfortran_add_compile_tests_from("${TESTS}")
+gfortran_populate_tests()

--- a/Fortran/gfortran/regression/asan/CMakeLists.txt
+++ b/Fortran/gfortran/regression/asan/CMakeLists.txt
@@ -6,7 +6,4 @@
 #
 #===------------------------------------------------------------------------===#
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_execute_tests_from("${TESTS}")
-gfortran_add_compile_tests_from("${TESTS}")
+gfortran_populate_tests()

--- a/Fortran/gfortran/regression/c-interop/CMakeLists.txt
+++ b/Fortran/gfortran/regression/c-interop/CMakeLists.txt
@@ -6,7 +6,4 @@
 #
 #===------------------------------------------------------------------------===#
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_execute_tests_from("${TESTS}")
-gfortran_add_compile_tests_from("${TESTS}")
+gfortran_populate_tests()

--- a/Fortran/gfortran/regression/coarray/CMakeLists.txt
+++ b/Fortran/gfortran/regression/coarray/CMakeLists.txt
@@ -6,7 +6,4 @@
 #
 #===------------------------------------------------------------------------===#
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_execute_tests_from("${TESTS}")
-gfortran_add_compile_tests_from("${TESTS}")
+gfortran_populate_tests()

--- a/Fortran/gfortran/regression/debug/CMakeLists.txt
+++ b/Fortran/gfortran/regression/debug/CMakeLists.txt
@@ -6,7 +6,4 @@
 #
 #===------------------------------------------------------------------------===#
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_execute_tests_from("${TESTS}")
-gfortran_add_compile_tests_from("${TESTS}")
+gfortran_populate_tests()

--- a/Fortran/gfortran/regression/g77/CMakeLists.txt
+++ b/Fortran/gfortran/regression/g77/CMakeLists.txt
@@ -6,7 +6,4 @@
 #
 #===------------------------------------------------------------------------===#
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_execute_tests_from("${TESTS}")
-gfortran_add_compile_tests_from("${TESTS}")
+gfortran_populate_tests()

--- a/Fortran/gfortran/regression/goacc-gomp/CMakeLists.txt
+++ b/Fortran/gfortran/regression/goacc-gomp/CMakeLists.txt
@@ -6,7 +6,4 @@
 #
 #===------------------------------------------------------------------------===#
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_execute_tests_from("${TESTS}")
-gfortran_add_compile_tests_from("${TESTS}" FFLAGS -fopenacc -fopenmp)
+gfortran_populate_tests(FFLAGS -fopenacc -fopenmp)

--- a/Fortran/gfortran/regression/goacc/CMakeLists.txt
+++ b/Fortran/gfortran/regression/goacc/CMakeLists.txt
@@ -6,7 +6,4 @@
 #
 #===------------------------------------------------------------------------===#
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_execute_tests_from("${TESTS}")
-gfortran_add_compile_tests_from("${TESTS}" FFLAGS -fopenacc)
+gfortran_populate_tests(FFLAGS -fopenacc)

--- a/Fortran/gfortran/regression/goacc/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/goacc/DisabledFiles.cmake
@@ -78,7 +78,7 @@ file(GLOB UNIMPLEMENTED_FILES CONFIGURE_DEPENDS
 # These tests are disabled because they cause flang to crash.
 file(GLOB SKIPPED_FILES CONFIGURE_DEPENDS
   # error: unsupported OpenACC operation:
-  acc.bounds array-with-dt-1a.f90
+  array-with-dt-1a.f90
   array-with-dt-1.f90
   array-with-dt-2.f90
   array-with-dt-3.f90

--- a/Fortran/gfortran/regression/gomp/CMakeLists.txt
+++ b/Fortran/gfortran/regression/gomp/CMakeLists.txt
@@ -6,7 +6,4 @@
 #
 #===------------------------------------------------------------------------===#
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_execute_tests_from("${TESTS}")
-gfortran_add_compile_tests_from("${TESTS}" FFLAGS -fopenmp)
+gfortran_populate_tests(FFLAGS -fopenmp)

--- a/Fortran/gfortran/regression/gomp/appendix-a/CMakeLists.txt
+++ b/Fortran/gfortran/regression/gomp/appendix-a/CMakeLists.txt
@@ -6,7 +6,4 @@
 #
 #===------------------------------------------------------------------------===#
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_execute_tests_from("${TESTS}")
-gfortran_add_compile_tests_from("${TESTS}" FFLAGS -fopenmp)
+gfortran_populate_tests(FFLAGS -fopenmp)

--- a/Fortran/gfortran/regression/ieee/CMakeLists.txt
+++ b/Fortran/gfortran/regression/ieee/CMakeLists.txt
@@ -6,7 +6,4 @@
 #
 #===------------------------------------------------------------------------===#
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_execute_tests_from("${TESTS}")
-gfortran_add_compile_tests_from("${TESTS}")
+gfortran_populate_tests()

--- a/Fortran/gfortran/regression/lto/CMakeLists.txt
+++ b/Fortran/gfortran/regression/lto/CMakeLists.txt
@@ -6,7 +6,4 @@
 #
 #===------------------------------------------------------------------------===#
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_execute_tests_from("${TESTS}")
-gfortran_add_compile_tests_from("${TESTS}")
+gfortran_populate_tests()

--- a/Fortran/gfortran/regression/ubsan/CMakeLists.txt
+++ b/Fortran/gfortran/regression/ubsan/CMakeLists.txt
@@ -6,7 +6,4 @@
 #
 #===------------------------------------------------------------------------===#
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_execute_tests_from("${TESTS}")
-gfortran_add_compile_tests_from("${TESTS}")
+gfortran_populate_tests()

--- a/Fortran/gfortran/regression/vect/CMakeLists.txt
+++ b/Fortran/gfortran/regression/vect/CMakeLists.txt
@@ -6,7 +6,4 @@
 #
 #===------------------------------------------------------------------------===#
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_execute_tests_from("${TESTS}")
-gfortran_add_compile_tests_from("${TESTS}")
+gfortran_populate_tests()

--- a/Fortran/gfortran/torture/compile/CMakeLists.txt
+++ b/Fortran/gfortran/torture/compile/CMakeLists.txt
@@ -6,6 +6,4 @@
 #
 #===------------------------------------------------------------------------===#
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_compile_tests("${TESTS}")
+gfortran_populate_tests()

--- a/Fortran/gfortran/torture/execute/CMakeLists.txt
+++ b/Fortran/gfortran/torture/execute/CMakeLists.txt
@@ -6,6 +6,4 @@
 #
 #===------------------------------------------------------------------------===#
 
-set(TESTS)
-gfortran_populate_tests(TESTS)
-gfortran_add_execute_tests("${TESTS}")
+gfortran_populate_tests()


### PR DESCRIPTION
Switches the existing build system to use the static test configuration files that were added to the repository in previous commits. The previous method is jettisoned in its entirety. Several tests have been disabled in the process. Some of these are because of limitations in the build system which will be fixed in the future. Others ought to have failed earlier but did not because they were not being built with the correct compiler flags. Now that they are built correctly, they expose limitations of flag which will need to be fixed.

-----------
[edit] Notes for reviewers:

- I may have disabled more tests than strictly necessary to have the default configuration pass. The next patch in this sequence will enable tests that are currently disabled and do pass, so those should get removed then.
