### PR TITLE
[Fortran] Disable internal_dummy_2.f08

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1014,6 +1014,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   char_pointer_assign_5.f90
   check_bits_1.f90 # requires -fcheck=bits to catch ISHFTC runtime error
   check_bits_2.f90 # requires -fcheck=bits to catch ISHFTC runtime error
+  internal_dummy_2.f08 # causes flang-new to crash in the backend (llvm-project/issues/76927)
   cr_lf.f90 # shenanigans with CR characters
   dollar_edit_descriptor_4.f # TODO: (i3,$) format shouldn't advance record when looping
   list_read_11.f90 # more CR character shenanigans


### PR DESCRIPTION
This was recently enabled in https://github.com/llvm/llvm-test-suite/pull/102

The CI is failing (https://lab.llvm.org/buildbot/#/builders/176/builds/8940) for this test. I can reproduce this locally. This could be an AArch64 specific issue but I do not have a way to verify this does not occur in other architectures, hence disabling.