### PR TITLE
[UnitTests/Float] Fix makefile in MultiSource/UnitTests/Float

### DIFF
--- a/MultiSource/UnitTests/Float/Makefile
+++ b/MultiSource/UnitTests/Float/Makefile
@@ -6,7 +6,7 @@ PARALLEL_DIRS :=
 
 # Tests in 'rounding' can run only if the target implements builtin functions
 # for rounding mode manipulation.
-ifneq (, $filter($(ARCH), X86_64 AArch64)
+ifneq (,$(filter $(ARCH), X86_64 AArch64))
 PARALLEL_DIRS += rounding
 endif
 


### PR DESCRIPTION
```
2024-04-05 01:59:00: running: "make" "-k" "TARGET_CC=None" "TARGET_CXX=None" "TARGET_LLVMGCC=/Users/nshc-yjlee_m/Library/Developer/LxShield/Xcode151_Test_15.1_1.15.1/bin/clang" "TARGET_LLVMGXX=/Users/nshc-yjlee_m/Library/Developer/LxShield/Xcode151_Test_15.1_1.15.1/bin/clang++" "TARGET_FLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" "ENABLE_OPTIMIZED=1" "OPTFLAGS=-Os" "LLI_OPTFLAGS=-O2" "LLC_OPTFLAGS=-O2" "DISABLE_JIT=1" "ENABLE_PARALLEL_REPORT=1" "ENABLE_HASHED_PROGRAM_OUTPUT=1" "USE_REFERENCE_OUTPUT=1" "TEST=simple" "CC_UNDER_TEST_IS_CLANG=1" "CC_UNDER_TEST_TARGET_IS_ARM64=1" "ARCH=AArch64" "-C" "MultiSource/UnitTests/Float/" "-j" "16" "report" "report.simple.csv"
Makefile:9: *** invalid syntax in conditional.  Stop.
```
The error occurred and I fixed it.