### PR TITLE
[SPEC] Workaround error with latest clang in 523.xalancbmk_r

### DIFF
--- a/External/SPEC/CINT2006/483.xalancbmk/CMakeLists.txt
+++ b/External/SPEC/CINT2006/483.xalancbmk/CMakeLists.txt
@@ -16,8 +16,8 @@ list(APPEND CXXFLAGS -std=gnu++98)
 
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-fdelayed-template-parsing
-                        HAVE_CXX_FLAG_FDELAYED_PARSING)
-if(HAVE_CXX_FLAG_FDELAYED_PARSING)
+                        HAVE_CXX_FLAG_FDELAYED_TEMPLATE_PARSING)
+if(HAVE_CXX_FLAG_FDELAYED_TEMPLATE_PARSING)
   add_compile_options(-fdelayed-template-parsing)
 endif()
 

--- a/External/SPEC/CINT2006/483.xalancbmk/CMakeLists.txt
+++ b/External/SPEC/CINT2006/483.xalancbmk/CMakeLists.txt
@@ -14,6 +14,13 @@ add_definitions(
 
 list(APPEND CXXFLAGS -std=gnu++98)
 
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-fdelayed-template-parsing
+                        HAVE_CXX_FLAG_FDELAYED_PARSING)
+if(HAVE_CXX_FLAG_FDELAYED_PARSING)
+  add_compile_options(-fdelayed-template-parsing)
+endif()
+
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${BENCHMARK_DIR}/src

--- a/External/SPEC/CINT2017rate/523.xalancbmk_r/CMakeLists.txt
+++ b/External/SPEC/CINT2017rate/523.xalancbmk_r/CMakeLists.txt
@@ -10,8 +10,8 @@ set(CMAKE_CXX_STANDARD 14)
 
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-fdelayed-template-parsing
-                        HAVE_CXX_FLAG_FDELAYED_PARSING)
-if(HAVE_CXX_FLAG_FDELAYED_PARSING)
+                        HAVE_CXX_FLAG_FDELAYED_TEMPLATE_PARSING)
+if(HAVE_CXX_FLAG_FDELAYED_TEMPLATE_PARSING)
   add_compile_options(-fdelayed-template-parsing)
 endif()
 

--- a/External/SPEC/CINT2017rate/523.xalancbmk_r/CMakeLists.txt
+++ b/External/SPEC/CINT2017rate/523.xalancbmk_r/CMakeLists.txt
@@ -8,6 +8,8 @@ speccpu2017_benchmark(RATE)
 
 set(CMAKE_CXX_STANDARD 14)
 
+add_compile_options(-fdelayed-template-parsing)
+
 add_definitions(
   -DAPP_NO_THREADS
   -DXALAN_INMEM_MSG_LOADER

--- a/External/SPEC/CINT2017rate/523.xalancbmk_r/CMakeLists.txt
+++ b/External/SPEC/CINT2017rate/523.xalancbmk_r/CMakeLists.txt
@@ -8,7 +8,12 @@ speccpu2017_benchmark(RATE)
 
 set(CMAKE_CXX_STANDARD 14)
 
-add_compile_options(-fdelayed-template-parsing)
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-fdelayed-template-parsing
+                        HAVE_CXX_FLAG_FDELAYED_PARSING)
+if(HAVE_CXX_FLAG_FDELAYED_PARSING)
+  add_compile_options(-fdelayed-template-parsing)
+endif()
 
 add_definitions(
   -DAPP_NO_THREADS


### PR DESCRIPTION
xalan-c contains a latent error in a template that isn't instantiated, which after https://github.com/llvm/llvm-project/pull/90152 will now fail to build. We can workaround it by setting -fdelayed-template-parsing. See https://github.com/llvm/llvm-project/pull/90152#issuecomment-2089786180
