### PR TITLE
Add litsupport module to collect QEMU plugin metrics

### DIFF
--- a/litsupport/CMakeLists.txt
+++ b/litsupport/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LITSUPPORT_FILES
   modules/microbenchmark.py
   modules/perf.py
   modules/profilegen.py
+  modules/qemulog.py
   modules/remote.py
   modules/run.py
   modules/run_under.py

--- a/litsupport/modules/qemulog.py
+++ b/litsupport/modules/qemulog.py
@@ -1,0 +1,51 @@
+"""test-suite/lit plugin to collect metrics from QEMU logs.
+
+If you are running the test suite under QEMU and are generating logs
+that contain metrics (typically from a plugin), you can use this
+module to:
+
+1. save the logs to a file
+2. parse any colon (:) separated metrics and collect them in the
+metrics
+
+For example, the example plugin libinsn.so outputs dynamic instruction
+counts in the following format:
+
+cpu 0 insns: 42
+total insns: 1024
+
+If you enable the plugin and tell QEMU to log it:
+
+-DTEST_SUITE_RUN_UNDER='qemu -plugin libinsn.so -d plugin'
+-DTEST_SUITE_EXTRA_LIT_MODULES=qemulog
+
+You can then compare those instruction counts later:
+
+./compare.py results.json -m 'total insns'
+
+"""
+
+from litsupport import shellcommand
+from litsupport import testplan
+from litsupport.modules import run_under
+
+
+def _mutateCommandLine(context, commandline):
+    context.qemulog = context.tmpBase + ".qemulog"
+    cmd = shellcommand.parse(commandline)
+    cmd.envvars.update({"QEMU_LOG_FILENAME": context.qemulog})
+    return cmd.toCommandline()
+
+
+def _getOutput(context):
+    with open(context.qemulog, "r") as f:
+        result = dict()
+        for line in f.read().splitlines():
+            [name, count] = line.split(":")
+            result[name] = int(count)
+        return result
+
+
+def mutatePlan(context, plan):
+    plan.runscript = testplan.mutateScript(context, plan.runscript, _mutateCommandLine)
+    plan.metric_collectors.append(_getOutput)


### PR DESCRIPTION
This is a pretty basic module I've been using that I thought I'd post here in case others find it useful.
It allows you to capture the logs from QEMU plugins and store them in the metrics for comparison with compare.py.

For example you can use the example plugin libinsn.so to gather the dynamic instruciton count:

```
$ cmake -B build -DTEST_SUITE_RUN_UNDER='qemu-foo -plugin libinsn.so -d plugin' \
  -DTEST_SUITE_EXTRA_LIT_MODULES=qemulog \
  -DTEST_SUITE_USER_MODE_EMULATION=ON
$ cmake --build build
$ lit build -o result.json
$ ./compare.py result.json -m 'total insns'
```

At the moment it only works if the plugin outputs metrics in 'foo:count' format, with one on each line.
