### PR TITLE
Add a check before using `-fno-define-target-os-macros`

### DIFF
--- a/MultiSource/Applications/ClamAV/CMakeLists.txt
+++ b/MultiSource/Applications/ClamAV/CMakeLists.txt
@@ -178,7 +178,11 @@ if(TARGET_OS STREQUAL "Linux")
   find_package(Intl REQUIRED)
   target_link_libraries(clamscan ${Intl_LIBRARIES})
 endif()
-if(APPLE)
+
+include(CheckCCompilerFlag)
+check_c_compiler_flag(-fno-define-target-os-macros
+                      COMPILER_HAS_NO_DEFINE_TARGET_OS_MACROS)
+if (COMPILER_HAS_NO_DEFINE_TARGET_OS_MACROS)
   # zlib fails to build with correctly defined target OS macros.
   # (https://github.com/madler/zlib/pull/895)
   # Disable the compiler extension to workaround the build failure until a zlib

--- a/MultiSource/Applications/ClamAV/CMakeLists.txt
+++ b/MultiSource/Applications/ClamAV/CMakeLists.txt
@@ -178,9 +178,11 @@ if(TARGET_OS STREQUAL "Linux")
   find_package(Intl REQUIRED)
   target_link_libraries(clamscan ${Intl_LIBRARIES})
 endif()
-# zlib fails to build with correctly defined target OS macros.
-# (https://github.com/madler/zlib/pull/895)
-# Disable the compiler extension to workaround the build failure until a zlib
-# source update with the fix.
-target_compile_options(clamscan PRIVATE -fno-define-target-os-macros)
+if(APPLE)
+  # zlib fails to build with correctly defined target OS macros.
+  # (https://github.com/madler/zlib/pull/895)
+  # Disable the compiler extension to workaround the build failure until a zlib
+  # source update with the fix.
+  target_compile_options(clamscan PRIVATE -fno-define-target-os-macros)
+endif()
 llvm_test_data(clamscan ${INPUT} dbdir)


### PR DESCRIPTION
I found an error when testing on a board that supports RISC-V Vector 1.0:

```shell
cc: error: unrecogized command-line option '-fno-define-target-os-macros'
```
I think the problem is probably caused by the lower version of cc?

```
gcc version 13.2.0
```

But I think we can refer to this commit to solve it.
https://github.com/llvm/llvm-test-suite/commit/9b14a92d585657b87f2ca2b135ba9044685393be

Add a condition that is only enabled on APPLE architecture for `-fno-define-target-os-macros`. 