### PR TITLE
[AIX][z/OS] Disable strip before hashing

### DIFF
--- a/litsupport/modules/hash.py
+++ b/litsupport/modules/hash.py
@@ -10,8 +10,8 @@ def compute(context):
         return
     executable = context.executable
     try:
-        # Darwin's and Solaris' "strip" don't support these arguments.
-        if platform.system() != "Darwin" and platform.system() != "SunOS":
+        # AIX, z/OS, and Darwin's and Solaris' "strip" don't support these arguments.
+        if platform.system() != 'OS/390' and platform.system() != 'AIX' and platform.system() != "Darwin" and platform.system() != "SunOS":
             stripped_executable = executable + ".stripped"
             testplan.check_call(
                 [


### PR DESCRIPTION
Similar to other platforms already opted out, these platforms strip utility does support the extra options used here.