### PR TITLE
Make code conform with Fortran standard

### DIFF
--- a/Fortran/gfortran/regression/assign_5.f90
+++ b/Fortran/gfortran/regression/assign_5.f90
@@ -10,6 +10,7 @@ go to a
 777 continue
 end
 program test
-call s1 (1)
+integer x
+call s1 (x)
 end
 


### PR DESCRIPTION
The original test "writes" to the argument a of s1, which is a constant value. This isn't valid in Fortran, and will fail if constant values are placed in read-only memory.

The original bug-report wasn't about using a constant argument to a function, but simply that the assign to doesn't work for some cases.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=22290

This patch fixes the test-code so that it is compliant with Fortran standard, by introducing a variable to assign into.