### PR TITLE
Disable non-conforming test

### DIFF
--- a/Fortran/UnitTests/CMakeLists.txt
+++ b/Fortran/UnitTests/CMakeLists.txt
@@ -1,4 +1,5 @@
 # This file should only contain add_subdirectory(...) one for each test
 add_subdirectory(hello)
+add_subdirectory(assign-goto)
 add_subdirectory(fcvs21_f95) # NIST Fortran Compiler Validation Suite
 add_subdirectory(finalization)

--- a/Fortran/UnitTests/assign-goto/CMakeLists.txt
+++ b/Fortran/UnitTests/assign-goto/CMakeLists.txt
@@ -1,0 +1,3 @@
+llvm_singlesource()
+
+file(COPY lit.local.cfg DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")

--- a/Fortran/UnitTests/assign-goto/assign-goto.f90
+++ b/Fortran/UnitTests/assign-goto/assign-goto.f90
@@ -1,0 +1,11 @@
+subroutine s(x)
+  integer :: x
+  assign 222 to x
+  goto x
+222 continue
+end subroutine s
+
+program test
+  integer :: a
+  call s(a)
+end program test

--- a/Fortran/UnitTests/assign-goto/lit.local.cfg
+++ b/Fortran/UnitTests/assign-goto/lit.local.cfg
@@ -1,0 +1,2 @@
+config.traditional_output = True
+config.single_source = True

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1534,6 +1534,10 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   directive_unroll_5.f90
   # Tests "!GCC$ attributes weak :: x"
   weak-3.f90
+  # Test is not conformant as it writes to a constant argument
+  # Similar test, that is conformant, added to hello.f90
+  assign_5.f90 
+   
 
   # Probable bugs
   # ["a", "ab"]

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1535,7 +1535,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   # Tests "!GCC$ attributes weak :: x"
   weak-3.f90
   # Test is not conformant as it writes to a constant argument
-  # Similar test, that is conformant, added to hello.f90
+  # Similar test, that is conformant, added to UnitTests/assign-goto
   assign_5.f90 
    
 


### PR DESCRIPTION
Replace it with our own similar test.

The gfortran/regression/assign_5.f90 writes to a constant value which would cause that test to fail if constants are read-only.

A replacement test assign-goto.f90 is introduced to check that this an assigned goto statement compiles and runs without issue.