### PR TITLE
Allow passing additional flags to the remote execution client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,9 @@ mark_as_advanced(TEST_SUITE_REMOTE_CLIENT)
 if(TEST_SUITE_REMOTE_HOST)
   add_custom_target(rsync
     COMMAND ${PROJECT_SOURCE_DIR}/utils/rsync.sh
-                ${TEST_SUITE_REMOTE_HOST} ${PROJECT_BINARY_DIR}
+                ${TEST_SUITE_REMOTE_CLIENT}
+                ${TEST_SUITE_REMOTE_HOST}
+                ${PROJECT_BINARY_DIR}
     USES_TERMINAL
   )
 endif()

--- a/utils/rsync.sh
+++ b/utils/rsync.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Sync a build directory to remote device for running.
 set -eu
-DEVICE="$1"
-BUILDDIR="$2"
+CLIENT="$1"
+DEVICE="$2"
+BUILDDIR="$3"
 
 case $BUILDDIR in
     /*) ;;
@@ -15,6 +16,7 @@ esac
 RSYNC_FLAGS=""
 RSYNC_FLAGS+=" -a"
 RSYNC_FLAGS+=" --delete --delete-excluded"
+RSYNC_FLAGS+=" -e \"$CLIENT\""
 # We cannot easily differentiate between intermediate build results and
 # files necessary to run the benchmark, so for now we just exclude based on
 # some file extensions...
@@ -30,5 +32,5 @@ RSYNC_FLAGS+=" --exclude=rules.ninja"
 RSYNC_FLAGS+=" --exclude=CMakeFiles/"
 
 set -x
-ssh $DEVICE mkdir -p "$BUILDDIR"
+$CLIENT $DEVICE mkdir -p "$BUILDDIR"
 eval rsync $RSYNC_FLAGS $BUILDDIR/ $DEVICE:$BUILDDIR/


### PR DESCRIPTION
`TEST_SUITE_REMOTE_CLIENT` can be used to pass additional flags to the remote execution client, such as specifying an alternative SSH configuration file.
For example: `TEST_SUITE_REMOTE_CLIENT="ssh -F path/to/config/file"`.