### PR TITLE
update Fortran tests for execute_command_line

### DIFF
--- a/Fortran/UnitTests/CMakeLists.txt
+++ b/Fortran/UnitTests/CMakeLists.txt
@@ -1,5 +1,6 @@
 # This file should only contain add_subdirectory(...) one for each test
 add_subdirectory(hello)
 add_subdirectory(assign-goto)
+add_subdirectory(execute_command_line)
 add_subdirectory(fcvs21_f95) # NIST Fortran Compiler Validation Suite
 add_subdirectory(finalization)

--- a/Fortran/UnitTests/execute_command_line/CMakeLists.txt
+++ b/Fortran/UnitTests/execute_command_line/CMakeLists.txt
@@ -1,0 +1,3 @@
+llvm_singlesource()
+
+file(COPY lit.local.cfg DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")

--- a/Fortran/UnitTests/execute_command_line/execute_command_line.f90
+++ b/Fortran/UnitTests/execute_command_line/execute_command_line.f90
@@ -1,0 +1,75 @@
+  integer :: i, j
+  character(len=100) :: msg
+  character(len=:), allocatable :: command
+  command='notthere'
+
+  msg = ""
+
+  call execute_command_line ("ls *.f90")
+
+  print *, "-----------------------------"
+
+  call execute_command_line ("sleep 1 ; ls *.f90", .false.)
+  print *, "I'm not waiting"
+  call sleep(2)
+
+  print *, "-----------------------------"
+
+  call execute_command_line ("sleep 1 ; ls *.f90", .true.)
+  print *, "I did wait"
+  call sleep(2)
+
+  print *, "-----------------------------"
+
+  call execute_command_line ("ls *.f90", .true., i)
+  print *, "Exist status was: ", i
+
+  print *, "-----------------------------"
+
+  call execute_command_line ("echo foo", .true., i, j)
+  print *, "Exist status was: ", i
+  print *, "Command status was: ", j
+
+  print *, "-----------------------------"
+
+  call execute_command_line ("echo foo", .true., i, j, msg)
+  print *, "Exist status was: ", i
+  print *, "Command status was: ", j
+  print *, "Error message is: ", trim(msg)
+
+  print *, "-----------------------------"
+
+  call execute_command_line ("ls *.doesnotexist", .true., i, j, msg)
+  print *, "Exist status was: ", i
+  print *, "Command status was: ", j
+  print *, "Error message is: ", trim(msg)
+
+  print *, "-----------------------------"
+
+  print *, "-------------Sync------------"
+  msg = ''
+  call execute_command_line("notthere",               exitstat=i, cmdstat=j, cmdmsg=msg)
+  if (j /= 5 .or. msg /= "Command not found with exit code: 127." ) STOP 1
+  call execute_command_line("cat GeneralErrorCommand", exitstat=i, cmdstat=j, cmdmsg=msg)
+  if (j /= 3 .or. msg /= "Command line execution failed with exit code: 1." ) STOP 2
+  msg = "remaining buffer not modified XXXXXXXXXXXXXXXXXXX"
+  call execute_command_line("touch NotExecutedCommandFile && chmod -x NotExecutedCommandFile && ./NotExecutedCommandFile", exitstat=i, cmdstat=j, cmdmsg=msg)
+  if (j /= 4 .or. msg /= "Command cannot be executed with exit code: 126.XX" ) STOP 3
+  msg = ''
+  call execute_command_line("notthere",               exitstat=i, cmdstat=j            )
+  if (j /= 5 .or. msg /= '' ) STOP 4
+
+  print *, "------------Async------------"
+  msg = ''
+  call execute_command_line("notthere", wait=.false., exitstat=i, cmdstat=j, cmdmsg=msg)
+  if (j /= 0 .or. msg /= '') STOP 5
+  j = 123
+  call execute_command_line("notthere", wait=.false., exitstat=i,            cmdmsg=msg)
+  if (j /= 123 .or. msg /= '') STOP 6
+  call execute_command_line("notthere", wait=.false., exitstat=i, cmdstat=j            )
+  if (j /= 0 .or. msg /= '') STOP 7
+  call execute_command_line("notthere", wait=.false., exitstat=i                       )
+  if (j /= 0 .or. msg /= '') STOP 8
+  
+
+  end

--- a/Fortran/UnitTests/execute_command_line/lit.local.cfg
+++ b/Fortran/UnitTests/execute_command_line/lit.local.cfg
@@ -1,0 +1,2 @@
+config.traditional_output = True
+config.single_source = True

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -332,7 +332,7 @@ file(GLOB UNIMPLEMENTED_FILES CONFIGURE_DEPENDS
   erf_3.F90
 
   # Test is not conformant as it expects different value of cmdstat and cmdmsg
-  # Similar test added: UnitTests/assign-goto
+  # Similar test added: UnitTests/execute_command_line
   execute_command_line_1.f90
   execute_command_line_3.f90
 

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -331,6 +331,11 @@ file(GLOB UNIMPLEMENTED_FILES CONFIGURE_DEPENDS
   erf_2.F90
   erf_3.F90
 
+  # Test is not conformant as it expects different value of cmdstat and cmdmsg
+  # Similar test added: UnitTests/assign-goto
+  execute_command_line_1.f90
+  execute_command_line_3.f90
+
   # unimplemented: intrinsic: failed_images
   coarray_failed_images_1.f08
 


### PR DESCRIPTION
`execute_command_line` was updated in https://github.com/llvm/llvm-project/pull/93023 with more `cmdstat` and richer `cmdmsg`, so existing test will fail.