### PR TITLE
[Fortran] enable gomp tests which now pass

### DIFF
--- a/Fortran/gfortran/regression/gomp/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/gomp/DisabledFiles.cmake
@@ -52,7 +52,6 @@ file(GLOB UNIMPLEMENTED_FILES CONFIGURE_DEPENDS
 
   # unimplemented: OpenMP Block construct clause
   pr71758.f90
-  pr77352.f90
   pr81887.f90
   target-device-2.f90
 
@@ -61,13 +60,9 @@ file(GLOB UNIMPLEMENTED_FILES CONFIGURE_DEPENDS
 
   # unimplemented: Unhandled block directive
   pr39152.f90
-  pr69128.f90
   pr69281.f90
-  pr70855.f90
   pr95869.f90
   teams-4.f90
-  workshare2.f90
-  workshare3.f90
 
   # unimplemented: OpenMPDeclareSimdConstruct
   pr79154-1.f90

--- a/Fortran/gfortran/regression/gomp/appendix-a/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/gomp/appendix-a/DisabledFiles.cmake
@@ -9,25 +9,13 @@
 # There are currently no unsupported files.
 set(UNSUPPORTED_FILES "")
 
-file(GLOB UNIMPLEMENTED_FILES CONFIGURE_DEPENDS
-  # unimplemented: Unhandled block directive
-  a.11.1.f90
-  a.11.2.f90
-  a.11.3.f90
-  a.11.4.f90
-  a.11.5.f90
-  a.11.6.f90
-  a.11.7.f90
-)
+# There are currently no files with unimplemented festures
+set(UNIMPLEMENTED_FILES "")
 
 file(GLOB SKIPPED_FILES CONFIGURE_DEPENDS
   #
   # These tests fail when they should pass.
   #
-
-  # error: COMMON block must be declared in the same scoping unit in which the
-  # OpenMP directive or clause appears
-  a.23.2.f90
 
   # error: COPYPRIVATE variable is not PRIVATE or THREADPRIVATE in outer
   # context


### PR DESCRIPTION
These were found through brute force. I haven't checked which PRs fixed them.