### PR TITLE
Fix MicroBenchmark build on Linux with clang 18.1.8

### DIFF
--- a/MicroBenchmarks/libs/benchmark/test/options_test.cc
+++ b/MicroBenchmarks/libs/benchmark/test/options_test.cc
@@ -67,6 +67,8 @@ void BM_explicit_iteration_count(benchmark::State& state) {
   assert(state.max_iterations == 42);
   size_t actual_iterations = 0;
   for (auto _ : state) ++actual_iterations;
+  benchmark::DoNotOptimize(actual_iterations);
+  assert(actual_iterations == 42);
   assert(state.iterations() == state.max_iterations);
   assert(state.iterations() == 42);
 }


### PR DESCRIPTION
MicroBenchmarks/libs/benchmark/test/options_test.cc fails to build on Linux/AArch64 with following error:
error: variable 'actual_iterations' set but not used

This patch adds benchmark::DoNotOptimize(actual_iterations); to to function BM_explicit_iteration_count in options_test.cc

-Wall and -Werror were being used to compile and I am surprised that this was not caught by any of the buildbots.
Some versions of clang compile this all fine with -Wall -Werror.