### PR TITLE
[llvm-test-suite][tools] Fix not utility to avoid std::system

### DIFF
--- a/tools/not.cpp
+++ b/tools/not.cpp
@@ -24,9 +24,12 @@
 #include <windows.h>
 #endif
 
-#ifdef __APPLE__
+#if defined(__unix__) || defined(__APPLE__)
 #include <spawn.h>
 #include <sys/wait.h>
+#endif
+
+#ifdef __APPLE__
 #include <TargetConditionals.h>
 #endif
 
@@ -56,20 +59,23 @@ int main(int argc, char* const* argv) {
     return 1;
 
   int result;
-#if !defined(TARGET_OS_IPHONE)
+#ifdef _WIN32
   std::stringstream ss;
   ss << argv[0];
   for (int i = 1; i < argc; ++i)
     ss << " " << argv[i];
   std::string cmd = ss.str();
   result = std::system(cmd.c_str());
-#else
+#elif defined(__unix__) || defined(__APPLE__)
   pid_t pid;
   if (posix_spawn(&pid, argv[0], NULL, NULL, argv, NULL))
     return EXIT_FAILURE;
   if (waitpid(pid, &result, WUNTRACED | WCONTINUED) == -1)
     return EXIT_FAILURE;
+#else
+  #error "Unsupported system"
 #endif
+
   int retcode = 0;
   int signal = 0;
 

--- a/tools/not.cpp
+++ b/tools/not.cpp
@@ -29,10 +29,6 @@
 #include <sys/wait.h>
 #endif
 
-#ifdef __APPLE__
-#include <TargetConditionals.h>
-#endif
-
 int main(int argc, char* const* argv) {
   bool expectCrash = false;
 
@@ -59,21 +55,20 @@ int main(int argc, char* const* argv) {
     return 1;
 
   int result;
-#ifdef _WIN32
-  std::stringstream ss;
-  ss << argv[0];
-  for (int i = 1; i < argc; ++i)
-    ss << " " << argv[i];
-  std::string cmd = ss.str();
-  result = std::system(cmd.c_str());
-#elif defined(__unix__) || defined(__APPLE__)
+
+#if defined(__unix__) || defined(__APPLE__)
   pid_t pid;
   if (posix_spawn(&pid, argv[0], NULL, NULL, argv, NULL))
     return EXIT_FAILURE;
   if (waitpid(pid, &result, WUNTRACED | WCONTINUED) == -1)
     return EXIT_FAILURE;
 #else
-  #error "Unsupported system"
+  std::stringstream ss;
+  ss << argv[0];
+  for (int i = 1; i < argc; ++i)
+    ss << " " << argv[i];
+  std::string cmd = ss.str();
+  result = std::system(cmd.c_str());
 #endif
 
   int retcode = 0;


### PR DESCRIPTION
Avoid using std::system on Unix systems. Some systems such as Ubuntu return a different error code from calls to std::system. Use posix_spawn to avoid having to special case these. std::system is now only used on Windows.

@jeanPerier identified this as an issue [here](https://github.com/llvm/llvm-test-suite/pull/102#issuecomment-1980674221)
@jroelofs, could you check that this doesn't cause any issues on iOS.