### PR TITLE
Check the returns of WIFSIGNALED and WIFEXITED

### DIFF
--- a/tools/not.cpp
+++ b/tools/not.cpp
@@ -96,7 +96,7 @@ int main(int argc, char* const* argv) {
   // On POSIX systems and Solaris, result is a composite value of the exit code
   // and, potentially, the signal that caused termination of the command.
   retcode = WEXITSTATUS(result);
-  signal = WTERMSIG(result);
+  signal = WIFSIGNALED(result);
 #else
 #error "Unsupported system"
 #endif

--- a/tools/not.cpp
+++ b/tools/not.cpp
@@ -92,11 +92,14 @@ int main(int argc, char* const* argv) {
     retcode = result;
     signal = 0;
   }
-#elif defined(WEXITSTATUS) && defined(WTERMSIG)
+#elif defined(WIFEXITED) && defined(WEXITSTATUS) && defined(WIFSIGNALED) &&    \
+    defined(WTERMSIG)
   // On POSIX systems and Solaris, result is a composite value of the exit code
   // and, potentially, the signal that caused termination of the command.
-  retcode = WEXITSTATUS(result);
-  signal = WIFSIGNALED(result);
+  if (WIFEXITED(result))
+    retcode = WEXITSTATUS(result);
+  if (WIFSIGNALED(result))
+    signal = WTERMSIG(result);
 #else
 #error "Unsupported system"
 #endif


### PR DESCRIPTION
In https://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html,
- for `WTERMSIG`, 
"If the value of WIFSIGNALED(stat_val) is non-zero, this macro evaluates to the number of the signal that caused the termination of the child process."
- for `WEXITSTATUS`,
"If the value of WIFEXITED(stat_val) is non-zero, this macro evaluates to the low-order 8 bits of the status argument ..."

We need to check `WIFSIGNALED` and `WIFEXTED` before using the values to update `rercode` and `signal`.   On AIX, if `WIFSIGNALED` is zero, `WTERMSIG` has a non-zero value (`0xffffffff`).

