### PR TITLE
Fix out-of-tree execution of lit

### DIFF
--- a/lit.cfg
+++ b/lit.cfg
@@ -53,5 +53,5 @@ if lit_config.params.get("profile") == "hpmcount":
     config.test_modules += ["hpmcount"]
 
 config.substitutions += [
-    ("%b", os.path.join(config.test_exec_root, "tools")),
+    ("%b", os.path.join(config.test_source_root, "tools")),
 ]


### PR DESCRIPTION
The lit substitution `%b` is used to find previously compiled helpers such as `fpcmp-target`; they're more likely to be in the test source directory (where the CMake artifacts are) than in the test exec directory (where lit is run). Note that the two are equal in the default site configuration, so this change matters only in environments with a custom site configuration file.