### PR TITLE
Fix GCC frame-address Regression test failure on Linux with clang 18.1.8

### DIFF
--- a/SingleSource/Regression/C/gcc-c-torture/execute/frame-address.c
+++ b/SingleSource/Regression/C/gcc-c-torture/execute/frame-address.c
@@ -19,7 +19,8 @@ int check_fa_mid (const char *c)
   const char *f = __builtin_frame_address (0);
 
   /* Prevent a tail call to check_fa_work, eliding the current stack frame.  */
-  return check_fa_work (c, f) != 0;
+  int (*volatile func_ptr)(const char *, const char *) = check_fa_work;
+  return func_ptr(c, f) != 0;
 }
 
 int check_fa (char *unused)
@@ -27,7 +28,8 @@ int check_fa (char *unused)
   const char c = 0;
 
   /* Prevent a tail call to check_fa_mid, eliding the current stack frame.  */
-  return check_fa_mid (&c) != 0;
+  int (*volatile func_ptr)(const char *) = check_fa_mid;
+  return func_ptr(&c) != 0;
 }
 
 int how_much (void)


### PR DESCRIPTION
SingleSource/Regression/C/gcc-c-torture/execute/frame-address.c fails on Linux/X86_64 with the following error:
Abort

Even though the code in frame-address.c tries to prevent tail call optimizations, clang still elides stack frames when O3 is enabled.

This patch uses volatile function pointers to
prevent the stack frame elision in frame-address.c