### PR TITLE
[Fortran/gfortran] Disable test to fix failing buildbots

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1741,4 +1741,9 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   fmt_en_rn.f90
   fmt_en_ru.f90
   fmt_en_rz.f90
+
+  # These test causes failures in some buildbots with an undefined reference to
+  # __trampoline_setup. This is probably an unrelated issue, but as a quick fix
+  # for the buildbot, this is disabled.
+  internal_dummy_2.f08
 )


### PR DESCRIPTION
Several of the AArch64 buildbots are failing due to an undefined reference to __trampoline_setup when compiling internal_dummy_2.f08. This is probably an issue with the buildbot configuration, but in the interest of getting them bots unstuck, the test is being disabled.