### PR TITLE
[Fortran/gfortran] Disable another test to fix failing buildbots

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -979,6 +979,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   #
   # https://github.com/llvm/llvm-test-suite/pull/102#issuecomment-1980674221
   #
+  do_check_1.f90
   pointer_check_1.f90
   pointer_check_2.f90
   pointer_check_3.f90


### PR DESCRIPTION
Fortran/gfortran/regression/gfortran-regression-execute-regression__do_check_1_f90.test
still fails after being re-enabled in #143
  https://lab.llvm.org/buildbot/#/builders/143/builds/1198