### PR TITLE
[flang] Disable submodule_3.f08

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1136,6 +1136,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   pure_formal_2.f90
   rank_2.f90
   realloc_on_assign_20.f90
+  submodule_3.f08
   type_decl_2.f90
   typebound_proc_3.f03
   typebound_proc_15.f03


### PR DESCRIPTION
The test Fortran/gfortran/regression/submodule_3.f08 is not expected to compile because it uses basic F'08 features while being compiled by gfortran under -std=f2003.  Flang-new wasn't compiling it either, but that was because it had a bug (also in gfortran) dealing with the inheritance of implicit typing rules in procedure interfaces. That bug is (or shortly will be) fixed, and the test now compiles without error, an unexpected result.  Disable the test.