### PR TITLE
[Fortran/gfortran] Disable flaky test random_init_2.f90

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1747,4 +1747,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   # __trampoline_setup. This is probably an unrelated issue, but as a quick fix
   # for the buildbot, this is disabled.
   internal_dummy_2.f08
+
+  # These are flaky tests, which may fail sometimes.
+  random_init_2.f90
 )


### PR DESCRIPTION
The random_init_2.f90 test is flaky and may fail sometimes, even
when no Fortran/Flang changes are made:
- https://lab.llvm.org/buildbot/#/builders/143/builds/1236
- https://lab.llvm.org/buildbot/#/builders/17/builds/2058

Looking at the test source, it seems there is no guarantee that 2
distinct random numbers will never collide. This is made worse by
multiplying them by 1e6 and converting them to integer, which could
make distinct but close enough single-precision floating-point
numbers give the same result and fail the test.
