### PR TITLE
[Fortran/gfortran][NFC] Recategorize tests

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1824,6 +1824,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   selected_logical_kind_2.f90
   submodule_3.f08
   submodule_33.f08
+  achar_2.f90
   allocate_with_source_30.f90
   allocate_with_source_31.f90
   backslash_1.f90

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -130,6 +130,11 @@ file(GLOB UNSUPPORTED_FILES CONFIGURE_DEPENDS
   # Test is not conformant as it writes to a constant argument
   # Similar test, that is conformant, added to UnitTests/assign-goto
   assign_5.f90
+
+  # Test is not conformant as it expects different value of cmdstat and cmdmsg
+  # Similar test added: UnitTests/execute_command_line
+  execute_command_line_1.f90
+  execute_command_line_3.f90
 )
 
 # These tests are skipped because they hit a 'not yet implemented' assertion
@@ -301,11 +306,6 @@ file(GLOB UNIMPLEMENTED_FILES CONFIGURE_DEPENDS
 
   # unimplemented: intrinsic: co_broadcast
   coarray_collectives_17.f90
-
-  # Test is not conformant as it expects different value of cmdstat and cmdmsg
-  # Similar test added: UnitTests/execute_command_line
-  execute_command_line_1.f90
-  execute_command_line_3.f90
 
   # unimplemented: intrinsic: failed_images
   coarray_failed_images_1.f08

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -120,12 +120,10 @@ file(GLOB UNSUPPORTED_FILES CONFIGURE_DEPENDS
   # Unsupported predefined macro: __TIMESTAMP__
   wdate-time.F90
 
-  # This test occasionally fails. It checks that two arrays initialized with
-  # random real numbers, converted to integers, are not identical. This might be
-  # the case in gfortran, but in flang, because of the precision loss and random
-  # nature of the test, it is possible, for two "randomly initialized" arrays to
-  # be identical. Unless something in flang's implementation of the RANDOM_*
-  # intrinsics changes, this test will be unsupported.
+  # This test checks that two arrays, initialized with random real numbers that
+  # are converted to integers, are not identical. It is possible, though
+  # unlikely for such "randomly initialized" arrays to be identical. Because of
+  # this inherent flakiness, this test will remain unsupported.
   random_init_2.f90
 
   # Test is not conformant as it writes to a constant argument

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -126,6 +126,10 @@ file(GLOB UNSUPPORTED_FILES CONFIGURE_DEPENDS
   # arrays to be identical. Unless something in flang's implementation of the
   # RANDOM_* intrinsics changes, this test will be unsupported.
   random_init_2.f90
+
+  # Test is not conformant as it writes to a constant argument
+  # Similar test, that is conformant, added to UnitTests/assign-goto
+  assign_5.f90
 )
 
 # These tests are skipped because they hit a 'not yet implemented' assertion
@@ -1415,10 +1419,6 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   directive_unroll_5.f90
   # Tests "!GCC$ attributes weak :: x"
   weak-3.f90
-  # Test is not conformant as it writes to a constant argument
-  # Similar test, that is conformant, added to UnitTests/assign-goto
-  assign_5.f90
-
 
   # Probable bugs
   # ["a", "ab"]
@@ -1828,7 +1828,6 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   selected_logical_kind_2.f90
   submodule_3.f08
   submodule_33.f08
-  achar_2.f90
   allocate_with_source_30.f90
   allocate_with_source_31.f90
   backslash_1.f90

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -121,10 +121,11 @@ file(GLOB UNSUPPORTED_FILES CONFIGURE_DEPENDS
   wdate-time.F90
 
   # This test occasionally fails. It checks that two arrays initialized with
-  # random numbers are not identical. This might be the case in gfortran, but in
-  # flang, it is possible, though unlikely, for two "randomly initialized"
-  # arrays to be identical. Unless something in flang's implementation of the
-  # RANDOM_* intrinsics changes, this test will be unsupported.
+  # random real numbers, converted to integers, are not identical. This might be
+  # the case in gfortran, but in flang, because of the precision loss and random
+  # nature of the test, it is possible, for two "randomly initialized" arrays to
+  # be identical. Unless something in flang's implementation of the RANDOM_*
+  # intrinsics changes, this test will be unsupported.
   random_init_2.f90
 
   # Test is not conformant as it writes to a constant argument

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -119,6 +119,13 @@ file(GLOB UNSUPPORTED_FILES CONFIGURE_DEPENDS
   unlimited_polymorphic_14.f90
   # Unsupported predefined macro: __TIMESTAMP__
   wdate-time.F90
+
+  # This test occasionally fails. It checks that two arrays initialized with
+  # random numbers are not identical. This might be the case in gfortran, but in
+  # flang, it is possible, though unlikely, for two "randomly initialized"
+  # arrays to be identical. Unless something in flang's implementation of the
+  # RANDOM_* intrinsics changes, this test will be unsupported.
+  random_init_2.f90
 )
 
 # These tests are skipped because they hit a 'not yet implemented' assertion
@@ -1792,9 +1799,6 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   # __trampoline_setup. This is probably an unrelated issue, but as a quick fix
   # for the buildbot, this is disabled.
   internal_dummy_2.f08
-
-  # These are flaky tests, which may fail sometimes.
-  random_init_2.f90
 
   # The causes of failure of these tests need to be investigated
   PR113061.f90

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1019,6 +1019,8 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   widechar_IO_4.f90
   zero_sized_1.f90
   elemental_function_2.f90
+  do_check_1.f90
+  random_3.f90
 
   # These tests fail at runtime on AArch64 (but pass on x86). Disable them
   # anyway so the test-suite passes by default on AArch64.
@@ -1026,18 +1028,11 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   findloc_8.f90
   pr99210.f90
 
-  # These tests fail on Ubuntu because of a bug in the not utility. At least
-  # some of these should work once the issue with not has been fixed.
-  #
-  # https://github.com/llvm/llvm-test-suite/pull/102#issuecomment-1980674221
-  #
-  do_check_1.f90
+  # These tests go into an infinite loop printing "Hello World"
   pointer_check_1.f90
   pointer_check_2.f90
   pointer_check_3.f90
   pointer_check_4.f90
-  random_3.f90
-  unpack_bounds_1.f90
 
   # ---------------------------------------------------------------------------
   #
@@ -1061,6 +1056,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   no_unit_error_1.f90
   pointer_check_10.f90
   pointer_remapping_6.f08
+  unpack_bounds_1.f90
 
   # ---------------------------------------------------------------------------
   #


### PR DESCRIPTION
Move some disabled tests to the "unsupported" category since these will never be fixed.

----------------

@lupori, could you check that the inline comment describing the `random_init_2.f90` test is correct. 