### PR TITLE
[Fortran] Disable pr32601.f03

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1840,4 +1840,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   pr111022.f90
   pr114304.f90
   zero_sized_15.f90
+
+  # Test needs to add -pedantic to show the error
+  pr32601.f03
 )

--- a/Fortran/gfortran/regression/pr32601.f03
+++ b/Fortran/gfortran/regression/pr32601.f03
@@ -1,5 +1,5 @@
 ! { dg-do compile }
-! { dg-options "-std=f2003" }
+! { dg-options "-std=f2003 -pedantic" }
 ! PR fortran/32601
 module pr32601
 use, intrinsic :: iso_c_binding, only: c_int

--- a/Fortran/gfortran/regression/pr32601.f03
+++ b/Fortran/gfortran/regression/pr32601.f03
@@ -1,5 +1,5 @@
 ! { dg-do compile }
-! { dg-options "-std=f2003 -pedantic" }
+! { dg-options "-std=f2003" }
 ! PR fortran/32601
 module pr32601
 use, intrinsic :: iso_c_binding, only: c_int


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/107353 will relax the check when -pedantic is not enabled. `-std=f2003` is not supported in flang. Disable the test until we have a way to add flags. 