### PR TITLE
[SPEC] Workaround error with latest clang in 510.parest_r

### DIFF
--- a/External/SPEC/CFP2017rate/510.parest_r/CMakeLists.txt
+++ b/External/SPEC/CFP2017rate/510.parest_r/CMakeLists.txt
@@ -6,6 +6,13 @@ endif ()
 
 speccpu2017_benchmark(RATE)
 
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-fno-relaxed-template-template-args
+                        HAVE_CXX_FLAG_FNO_RELAXED_TEMPLATE_TEMPLATE_ARGS)
+if(HAVE_CXX_FLAG_FNO_RELAXED_TEMPLATE_TEMPLATE_ARGS)
+  add_compile_options(-fno-relaxed-template-template-args)
+endif()
+
 speccpu2017_add_include_dirs(include .)
 
 ## test ########################################################################


### PR DESCRIPTION
Similarly to #118, 510.parest_r contains another latent error related to template deduction that after https://github.com/llvm/llvm-project/pull/100692 fails to build. We can workaround this by passing -fno-relaxed-template-template-args
