### PR TITLE
[SPEC] Define arch/os portability flag for riscv64-linux-gnu

### DIFF
--- a/External/SPEC/SpecCPU2017.cmake
+++ b/External/SPEC/SpecCPU2017.cmake
@@ -157,6 +157,8 @@ macro (speccpu2017_benchmark)
     elseif (ARCH STREQUAL "AArch64" AND TARGET_OS STREQUAL "Linux" AND CMAKE_SIZEOF_VOID_P EQUAL 8)
       # Linux ARM
       list(APPEND SPEC_COMMON_DEFS "-DSPEC_LINUX_AARCH64")
+    elseif (ARCH STREQUAL "riscv64")
+      list(APPEND SPEC_COMMON_DEFS "-DSPEC_MANUAL_CONFIG")
     elseif (ARCH STREQUAL "x86" AND TARGET_OS STREQUAL "Windows")
       # Windows x86/x64
     elseif (TARGET_OS STREQUAL "Darwin")


### PR DESCRIPTION
Without -DSPEC_MANUAL_CONFIG (or another dummy arch/os flag specified), 500.perlbench_r will fail to build on riscv64-linux-gnu. -DSPEC_LP64 and -DSPEC_LINUX are also already defined via the generic handlers above. I'm not sure if we need to define more flags, but this enough to get things building.
