### PR TITLE
Fix spurious errors in halide tests

### DIFF
--- a/Bitcode/Benchmarks/Halide/CMakeLists.txt
+++ b/Bitcode/Benchmarks/Halide/CMakeLists.txt
@@ -10,11 +10,11 @@ if(NOT MSVC)
 endif()
 
 macro(test_img_input img)
-  llvm_test_run(%S/../images/${img}.bytes ${ARGN} %S/${img}_out.bytes)
+  llvm_test_run(%S/images/${img}.bytes ${ARGN} %S/${img}_out.bytes)
   llvm_test_verify(%b/${FPCMP} %S/output/${img}_out.bytes %S/${img}_out.bytes)
 endmacro()
 macro(test_img_data target img)
-  llvm_test_data(${target} ../images/${img}.bytes)
+  llvm_test_data(${target} SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/.. images/${img}.bytes)
   llvm_test_data(${target} output/${img}_out.bytes)
 endmacro()
 


### PR DESCRIPTION
We occasionally see spurious llvm-test-suite failures with the following error message:

    CMake Error: failed to create symbolic link '/tmp/tmp.x1PxF3OhCA/Bitcode/Benchmarks/Halide/local_laplacian/../images/rgb.bytes': File exists

The reason for this is that two halide tests try to copy a test input to the same location, and create_symlink can fail if these calls race.

Fix this by putting the inputs for the tests into different directories, by not making ".." part of the result directory.