### PR TITLE
fpcmp: Dump inputs on comparison failure

### DIFF
--- a/tools/fpcmp.c
+++ b/tools/fpcmp.c
@@ -247,8 +247,25 @@ char *load_file(const char *path, long *size_out) {
   return data;
 }
 
-void dump_inputs(const char *data_a, const char *data_b) {
-    fprintf(stderr, "\nInput 1:\n%s\nInput 2:\n%s", data_a, data_b);
+static bool contains_non_printable_characters(const char *data) {
+  size_t len = strlen(data);
+  for (size_t i = 0; i < len; ++i)
+    if (!isprint(data[i]) && !isspace(data[i]))
+      return true;
+  return false;
+}
+
+static void dump_input(const char *label, const char *data) {
+  if (contains_non_printable_characters(data)) {
+    fprintf(stderr, "\n%s: Contains binary data.\n", label);
+  } else {
+    fprintf(stderr, "\n%s:\n%s", label, data);
+  }
+}
+
+static void dump_inputs(const char *data_a, const char *data_b) {
+  dump_input("Input 1", data_a);
+  dump_input("Input 2", data_b);
 }
 
 int diff_file(const char *path_a, const char *path_b, bool parse_fp,

--- a/tools/fpcmp.c
+++ b/tools/fpcmp.c
@@ -247,6 +247,10 @@ char *load_file(const char *path, long *size_out) {
   return data;
 }
 
+void dump_inputs(const char *data_a, const char *data_b) {
+    fprintf(stderr, "\nInput 1:\n%s\nInput 2:\n%s", data_a, data_b);
+}
+
 int diff_file(const char *path_a, const char *path_b, bool parse_fp,
               double absolute_tolerance, double relative_tolerance,
               bool ignore_whitespace) {
@@ -356,6 +360,7 @@ int diff_file(const char *path_a, const char *path_b, bool parse_fp,
     fprintf(stderr,
             "%s: Comparison failed, textual difference between '%c' and '%c'\n",
             g_program, F1P[0], F2P[0]);
+    dump_inputs(data_a, data_b);
     free(data_a);
     free(data_b);
     return 1;
@@ -364,6 +369,7 @@ int diff_file(const char *path_a, const char *path_b, bool parse_fp,
     fprintf(stderr,
             "%s: Comparison failed, unexpected end of one of the files\n",
             g_program);
+    dump_inputs(data_a, data_b);
     free(data_a);
     free(data_b);
     return 1;


### PR DESCRIPTION
There are occasionally spurious failures in llvm-test-suite, and you end up with a phenomenally unhelpful message like:

    tools/fpcmp-target: Comparison failed, textual difference between '0' and '7'

This is good enough if you can inspect the inputs to fpcmp locally, but unhelpful for CI failures.

Improve things by dumping the inputs to fpcmp on a textual comparison failure.