### PR TITLE
[flang] Disable two tests as error is being downgraded

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1301,6 +1301,8 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   pr95614_2.f90
   pr95882_3.f90
   recursive_check_3.f90
+  restricted_expression_2.f90
+  restricted_expression_3.f90
   return_1.f90
   size_kind_3.f90
   string_3.f90


### PR DESCRIPTION
Fortran/gfortran/regression/restricted_expression_2.f90 and Fortran/gfortran/regression/restricted_expression_3.f90 are disabled with this patch, as the condition that they test will soon no longer be an error with flang, just a warning. (This is the use of a local variable with proper initialization and the SAVE attribute being used as part of a specification expression.)