### PR TITLE
[FMV][AArch64] Add tests for feature ls64.

### DIFF
--- a/SingleSource/UnitTests/AArch64/acle-fmv-features.c
+++ b/SingleSource/UnitTests/AArch64/acle-fmv-features.c
@@ -242,6 +242,18 @@ CHECK(sme2, sme2, {
         "smstop  za" "\n"
     );
 })
+CHECK(ls64, ls64, {
+    long data[8];
+    asm volatile (
+        "ld64b x0, [%0]" "\n"
+        "st64b x0, [%0]" "\n"
+        "st64bv x8, x0, [%0]" "\n"
+        "st64bv0 x8, x0, [%0]" "\n"
+        :
+        : "r" (data)
+        : "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "memory"
+    );
+})
 
 static bool safe_try_feature(bool (*try_feature)(void)) {
     int child = fork();
@@ -283,6 +295,7 @@ int main(int, const char **) {
     check_crc();
     check_sme();
     check_sme2();
+    check_ls64();
 
     return any_fails ? -1 : 0;
 }

--- a/SingleSource/UnitTests/AArch64/acle-fmv-features.reference_output
+++ b/SingleSource/UnitTests/AArch64/acle-fmv-features.reference_output
@@ -25,4 +25,5 @@ fp
 crc
 sme
 sme2
+ls64
 exit 0


### PR DESCRIPTION
The inline asm tests all three FEAT_LS64, FEAT_LS64_V and FEAT_LS64_ACCDATA.