### PR TITLE
[flang] Disable test that expects error from new extension

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1052,6 +1052,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   io_real_boz2.f90
   io_real_boz_4.f90
   io_real_boz_5.f90
+  namelist_96.f90 # real data for integer NAMELIST input
   no_unit_error_1.f90
   pointer_check_10.f90
   pointer_remapping_6.f08


### PR DESCRIPTION
I'm shortly adding the ability to allow real-looking input for NAMELIST integer values.  GNU Fortran doesn't allow that, and has a test to check its error detection, so disable that test.