### PR TITLE
[FMV][AArch64] Unify tests for sha1 and sha2.

### DIFF
--- a/SingleSource/UnitTests/AArch64/acle-fmv-features.c
+++ b/SingleSource/UnitTests/AArch64/acle-fmv-features.c
@@ -92,14 +92,7 @@ CHECK(sha2, sha2, {
         "fmov d0, #0" "\n"
         "fmov d1, #0" "\n"
         "sha256h q0, q0, v0.4s" "\n"
-        : : : "v0"
-    );
-})
-CHECK(sha1, sha1, {
-    asm volatile (
-        "fmov s0, #0" "\n"
-        // FIXME: sha1h is under +sha2 in clang, and +sha1 doesn't exist yet.
-        ".inst 0x5e280800" "\n" // sha1h s0, s0
+        "sha1h s0, s0" "\n"
         : : : "v0"
     );
 })
@@ -263,7 +256,6 @@ int main(int, const char **) {
     check_rdm();
     check_lse();
     check_sha2();
-    check_sha1();
     check_aes();
     check_pmull();
     check_rcpc();

--- a/SingleSource/UnitTests/AArch64/acle-fmv-features.reference_output
+++ b/SingleSource/UnitTests/AArch64/acle-fmv-features.reference_output
@@ -5,7 +5,6 @@ sha3
 rdm
 lse
 sha2
-sha1
 aes
 pmull
 rcpc


### PR DESCRIPTION
Sha1 has been unified with sha2 in the ACLE spec (https://github.com/ARM-software/acle/pull/347) and soon in the compiler (https://github.com/llvm/llvm-project/pull/108383), therefore I am adjusting the runtime tests for it.