### PR TITLE
[FMV][AArch64] Fix UPASS when "SSBS not fully self-synchronizing".

### DIFF
--- a/SingleSource/UnitTests/AArch64/acle-fmv-features.c
+++ b/SingleSource/UnitTests/AArch64/acle-fmv-features.c
@@ -38,7 +38,7 @@ static bool any_fails = false;
         printf("%s\n", #FMV_FEATURE); \
         fflush(stdout); \
         /* default versions are allowed to UPASS when IS_EXEMPT = true */ \
-        if (safe_try_feature(try_##FN_NAME_SUFFIX, #IS_EXEMPT)) { \
+        if (safe_try_feature(try_##FN_NAME_SUFFIX, IS_EXEMPT)) { \
             printf("\tUPASS\n"); \
             any_fails = true; \
         } \


### PR DESCRIPTION
When running try_ssbs2() on hardware which is affected by the "SSBS not fully self-synchronizing" errata, the linux kernel mutes the detection of ssbs2 via hardware caps. As a result the default version ends up running the ssbs2 code which was expected to trap originally.

To work around this UPASS I am passing an additional macro parameter to indicate whether the default version is exempt from diagnostics.

This fixes https://github.com/llvm/llvm-project/issues/109304.