### PR TITLE
[Fortran] disbale failing tests after assumed-rank were enabled

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1199,6 +1199,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   pr90290.f90
   pr91564.f90
   rank_3.f90
+  assumed_rank_5.f90
 
   # Requires behaviour specific to -std=f2008 and fails with -std=f2018.
   finalize_38a.f90
@@ -1846,4 +1847,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
 
   # Test needs to add -pedantic to show the error
   pr32601.f03
+
+  # Tests expect semantic errors that are not raised.
+  c_sizeof_7.f90
 )

--- a/Fortran/gfortran/regression/c-interop/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/c-interop/DisabledFiles.cmake
@@ -124,4 +124,9 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   # These files are expected to fail to compile, but succeed instead.
   c516.f90
   c524a.f90
+  c535b-3.f90
+  c535c-1.f90
+  c535c-2.f90
+  c535c-3.f90
+  c535c-4.f90
 )


### PR DESCRIPTION
Fix https://lab.llvm.org/buildbot/#/builders/143/builds/2600

Some tests expecting a semantic error wrongly passed because of the lowering TODO for assumed rank that was enabled by default in https://github.com/llvm/llvm-project/pull/110893.