### PR TITLE
[flang] Disable two xfail tests that will soon not fail

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1850,4 +1850,8 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
 
   # Tests expect semantic errors that are not raised.
   c_sizeof_7.f90
+
+  # Tests that use "PRINT namelistname"
+  namelist_print_2.f
+  print_fmt_2.f90
 )


### PR DESCRIPTION
An upcoming PR to flang (https://github.com/llvm/llvm-project/pull/112024) will soon allow two gfortran tests to compile and run successfully, which will come as a fatal surprise because they're marked "xfail".