### PR TITLE
[FMV][AArch64] Add runtime test for memtag.

### DIFF
--- a/SingleSource/UnitTests/AArch64/acle-fmv-features.c
+++ b/SingleSource/UnitTests/AArch64/acle-fmv-features.c
@@ -369,6 +369,15 @@ CHECK(mops, mops, mops, false, {
          : : "cc", "memory"
      );
 })
+// We can't use any FEAT_MTE2 instruction in this test since they are undefined
+// at EL0. Therefore passing IS_EXEMPT = true here allows the default version to
+// UPASS on a system which doesn't have FEAT_MTE2 but has FEAT_MTE.
+CHECK(memtag, memtag, memtag, true, {
+    asm volatile (
+        "irg x0, sp"
+        : : : "x0"
+    );
+})
 
 static bool safe_try_feature(bool (*try_feature)(void), bool is_exempt) {
     int child = fork();
@@ -428,6 +437,7 @@ int main(int, const char **) {
     check_sme_f64f64();
     check_sme_i16i64();
     check_mops();
+    check_memtag();
 
     return any_fails ? -1 : 0;
 }

--- a/SingleSource/UnitTests/AArch64/acle-fmv-features.reference_output
+++ b/SingleSource/UnitTests/AArch64/acle-fmv-features.reference_output
@@ -43,4 +43,5 @@ sm4
 sme-f64f64
 sme-i16i64
 mops
+memtag
 exit 0


### PR DESCRIPTION
There are no FEAT_MTE2 instructions available at EL0, therefore this test is expected to UPASS on systems which support FEAT_MTE but don't support FEAT_MTE2.

Depends on https://github.com/llvm/llvm-project/pull/112511