### PR TITLE
[LoongArch] Add vector floating-point check function

### DIFF
--- a/SingleSource/UnitTests/Vector/LASX/lasx-xvfmadd_d.c
+++ b/SingleSource/UnitTests/Vector/LASX/lasx-xvfmadd_d.c
@@ -124,7 +124,8 @@ main ()
   v4u64_result = (v4u64){0xffffffffffffffff, 0xffffba8300004fc2,
                          0xffffffffffffffff, 0xffffba8300004fc2};
   __m256d_out = __lasx_xvfmadd_d((__m256)v4u64_op0, (__m256)v4u64_op1, (__m256)v4u64_op2);
-  check_lasx_out(&v4u64_result, &__m256d_out, sizeof(__m256d_out), __FILE__, __LINE__);
+  check_lasx_fp_out(1, &v4u64_result, &__m256d_out, sizeof(__m256d_out),
+                    __FILE__, __LINE__);
 
   v4u64_op0 = (v4u64){0x0000000000000000, 0x0000000000000000,
                       0x0000000000000000, 0x0000000000000000};
@@ -146,7 +147,8 @@ main ()
   v4u64_result = (v4u64){0xffffffffff000000, 0x0000000000000000,
                          0xffffffffff000000, 0x0000000000000000};
   __m256d_out = __lasx_xvfmadd_d((__m256)v4u64_op0, (__m256)v4u64_op1, (__m256)v4u64_op2);
-  check_lasx_out(&v4u64_result, &__m256d_out, sizeof(__m256d_out), __FILE__, __LINE__);
+  check_lasx_fp_out(1, &v4u64_result, &__m256d_out, sizeof(__m256d_out),
+                    __FILE__, __LINE__);
 
   v4u64_op0 = (v4u64){0x00003fff00003fff, 0x00003fff00003fff,
                       0x00003fff00003fff, 0x00003fff00003fff};

--- a/SingleSource/UnitTests/Vector/LASX/lasx_test_util.h
+++ b/SingleSource/UnitTests/Vector/LASX/lasx_test_util.h
@@ -1,6 +1,7 @@
 #ifndef LASX_TEST_UTIL_H
 #define LASX_TEST_UTIL_H
 
+#include <math.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -23,6 +24,27 @@ __attribute__((noinline)) void check_lasx_out(void *expected, void *got,
       printf(" %02x", ((char *)got)[i] & 0xff);
     }
     printf("\n");
+  }
+}
+
+// Used for comparing floating-point results when the result is NAN, but the
+// bitwise comparison with the expected NAN differs.
+__attribute__((noinline)) void check_lasx_fp_out(_Bool IsDouble, void *expected,
+                                                 void *got, int len,
+                                                 const char *fname, int line) {
+  // num of elements
+  int N = IsDouble == 1 ? 8 : 4;
+  for (int i = 0; i < 32; i += N) {
+    if (!memcmp(expected + i, got + i, N))
+      continue;
+    if (IsDouble && isnan(*(double *)(expected + i)) &&
+        isnan(*(double *)(got + i)))
+      continue;
+    if (!IsDouble && isnan(*(float *)(expected + i)) &&
+        isnan(*(float *)(got + i)))
+      continue;
+    check_lasx_out(expected, got, len, fname, line);
+    return;
   }
 }
 

--- a/SingleSource/UnitTests/Vector/LSX/lsx-vfmadd_d.c
+++ b/SingleSource/UnitTests/Vector/LSX/lsx-vfmadd_d.c
@@ -70,7 +70,8 @@ main ()
   v2u64_op2 = (v2u64){0xfff8000000000000, 0xfffb00fdfdf7ffff};
   v2u64_result = (v2u64){0xfff8000000000000, 0xfffb00fdfdf7ffff};
   __m128d_out = __lsx_vfmadd_d((__m128)v2u64_op0, (__m128)v2u64_op1, (__m128)v2u64_op2);
-  check_lsx_out(&v2u64_result, &__m128d_out, sizeof(__m128d_out), __FILE__, __LINE__);
+  check_lsx_fp_out(1, &v2u64_result, &__m128d_out, sizeof(__m128d_out),
+                   __FILE__, __LINE__);
 
   v2u64_op0 = (v2u64){0x8000000000000000, 0x8000000000000000};
   v2u64_op1 = (v2u64){0x0000000000000000, 0x0000000000000000};

--- a/SingleSource/UnitTests/Vector/LSX/lsx_test_util.h
+++ b/SingleSource/UnitTests/Vector/LSX/lsx_test_util.h
@@ -1,6 +1,7 @@
 #ifndef LSX_TEST_UTIL_H
 #define LSX_TEST_UTIL_H
 
+#include <math.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -22,6 +23,27 @@ __attribute__((noinline)) void check_lsx_out(void *expected, void *got, int len,
       printf(" %02x", ((char *)got)[i] & 0xff);
     }
     printf("\n");
+  }
+}
+
+// Used for comparing floating-point results when the result is NAN, but the
+// bitwise comparison with the expected NAN differs.
+__attribute__((noinline)) void check_lsx_fp_out(_Bool IsDouble, void *expected,
+                                                void *got, int len,
+                                                const char *fname, int line) {
+  // num of elements
+  int N = IsDouble == 1 ? 8 : 4;
+  for (int i = 0; i < 16; i += N) {
+    if (!memcmp(expected + i, got + i, N))
+      continue;
+    if (IsDouble && isnan(*(double *)(expected + i)) &&
+        isnan(*(double *)(got + i)))
+      continue;
+    if (!IsDouble && isnan(*(float *)(expected + i)) &&
+        isnan(*(float *)(got + i)))
+      continue;
+    check_lsx_out(expected, got, len, fname, line);
+    return;
   }
 }
 


### PR DESCRIPTION
Because vector support for constant folding was added in visitFMA, the [x]vfmadd.d instructions was optimized into a constant load, causing a bitwise mismatch for NaN values between the expected and actual results. (The NaN from constant folding differs from the NaN generated by the
 instruction.)

This should resolve the buildbot failure:
https://lab.llvm.org/staging/#/builders/20/builds/4041