### PR TITLE
temporarily disable HIP test InOneWeekend

### DIFF
--- a/External/HIP/CMakeLists.txt
+++ b/External/HIP/CMakeLists.txt
@@ -16,7 +16,9 @@ macro(create_local_hip_tests VariantSuffix)
   list(APPEND HIP_LOCAL_TESTS with-fopenmp)
   list(APPEND HIP_LOCAL_TESTS saxpy)
   list(APPEND HIP_LOCAL_TESTS memmove)
-  list(APPEND HIP_LOCAL_TESTS InOneWeekend)
+
+  # TODO: Re-enable InOneWeekend after it is fixed
+  #list(APPEND HIP_LOCAL_TESTS InOneWeekend)
   list(APPEND HIP_LOCAL_TESTS TheNextWeek)
 
   # Copy files needed for ray-tracing tests.


### PR DESCRIPTION
since it is unstable and causes spurious random failures