### PR TITLE
[FMV][AArch64] Remove features which expose non exploitable runtime behavior.

### DIFF
--- a/SingleSource/UnitTests/AArch64/acle-fmv-features.c
+++ b/SingleSource/UnitTests/AArch64/acle-fmv-features.c
@@ -162,12 +162,6 @@ CHECK(i8mm, i8mm, i8mm, false, {
         : : : "v0"
     );
 })
-CHECK(dit, dit, dit, false, {
-    asm volatile (
-        "msr DIT, x0"
-        : : : "x0"
-    );
-})
 CHECK(fp16, fp16, fp16, false, {
     asm volatile (
         "fmov h0, #0"
@@ -409,7 +403,6 @@ int main(int, const char **) {
     check_dpb2();
     check_bf16();
     check_i8mm();
-    check_dit();
     check_fp16();
     check_ssbs();
     check_bti();

--- a/SingleSource/UnitTests/AArch64/acle-fmv-features.reference_output
+++ b/SingleSource/UnitTests/AArch64/acle-fmv-features.reference_output
@@ -14,7 +14,6 @@ dpb
 dpb2
 bf16
 i8mm
-dit
 fp16
 ssbs
 bti


### PR DESCRIPTION
Feature dit provides independent timing for data processing instructions according to the value CPSR.DIT of the Current Program Status Register.

The runtime detection in FMV does not examine the content of control registers, therefore such features are not suitable for runtime dispatch since they cannot be exploited in a meaningful way. See the ACLE patch for more info: https://github.com/ARM-software/acle/pull/355

Depends on https://github.com/llvm/llvm-project/pull/114387