### PR TITLE
[tools] Make not tool respect environment variables

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -41,3 +41,7 @@ else()
 endif()
 
 add_executable(not ${CMAKE_CURRENT_SOURCE_DIR}/not.cpp)
+
+# Always add the test subdirectory. After all, we really should test these
+# tools.
+add_subdirectory(test)

--- a/tools/not.cpp
+++ b/tools/not.cpp
@@ -58,7 +58,8 @@ int main(int argc, char* const* argv) {
 
 #if defined(__unix__) || defined(__APPLE__)
   pid_t pid;
-  if (posix_spawn(&pid, argv[0], NULL, NULL, argv, NULL))
+  extern char** environ;
+  if (posix_spawn(&pid, argv[0], NULL, NULL, argv, environ))
     return EXIT_FAILURE;
   if (waitpid(pid, &result, WUNTRACED | WCONTINUED) == -1)
     return EXIT_FAILURE;

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copy these files to the build directory so that the tests can be run even
+# without the source directory.
+configure_file(test_not.sh test_not.sh
+  @ONLY)
+
+add_executable(ret1 ret1.c)
+llvm_test_run(EXECUTABLE "%b/not" "%b/test/ret1")
+llvm_add_test_for_target(ret1)
+
+add_executable(ret0 ret0.c)
+llvm_test_run(EXECUTABLE "%b/not" "%b/not" "%b/test/ret0")
+llvm_add_test_for_target(ret0)
+
+# Check that expected crashes are handled correctly.
+add_executable(abrt abort.c)
+llvm_test_run(EXECUTABLE "%b/not" "--crash" "%b/test/abrt")
+llvm_add_test_for_target(abrt)
+
+# Check that not passes environment variables to the called executable.
+add_executable(check_env check_env.c)
+llvm_test_run(EXECUTABLE "/bin/bash" "%b/test/test_not.sh %b")
+llvm_add_test(test_not.test test_not.sh)

--- a/tools/test/abort.c
+++ b/tools/test/abort.c
@@ -1,0 +1,5 @@
+#include <stdlib.h>
+
+int main(int argc, char* argv[]) {
+  abort();
+}

--- a/tools/test/check_env.c
+++ b/tools/test/check_env.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+int main(int argc, char* argv[]) {
+  // SET_IN_PARENT will have been set in by the driver, test_not.sh.
+  // NOT_IN_PARENT will not have been set. Calling getenv with the former will
+  // return non-NULL, the latter will return NULL. If both conditions are true,
+  // this will return non-zero (which is an "error" code). This is intentional
+  // because this will be passed to not which expects an error code.
+
+  return getenv("SET_IN_PARENT") && !getenv("NOT_IN_PARENT");
+}

--- a/tools/test/ret0.c
+++ b/tools/test/ret0.c
@@ -1,0 +1,3 @@
+int main(int argc, char* argv[]) {
+  return 0;
+}

--- a/tools/test/ret1.c
+++ b/tools/test/ret1.c
@@ -1,0 +1,3 @@
+int main(int argc, char* argv[]) {
+  return 1;
+}

--- a/tools/test/test_not.sh
+++ b/tools/test/test_not.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+#
+# USAGE: test_not.sh ${bindir}
+#
+# where bindir is ${CMAKE_BINARY_DIR}/tools
+
+export SET_IN_PARENT="something"
+$1/not $1/test/check_env


### PR DESCRIPTION
The not utility did not capture the parent's environment variables on POSIX platforms. This has been fixed.

---------------------------
@jroelofs 

Is this valid on Apple platforms?