### PR TITLE
[cmake] Support more Fortran filename suffixes

### DIFF
--- a/cmake/modules/SingleMultiSource.cmake
+++ b/cmake/modules/SingleMultiSource.cmake
@@ -33,7 +33,9 @@ function(llvm_singlesource)
   if(DEFINED Source)
     set(sources ${Source})
   else()
-    file(GLOB sources *.c *.cpp *.cc *.f *.F *.f90 *.F90 *.f03 *.F03 *.f08 *.F08)
+    file(GLOB sources
+         *.c *.cpp *.cc
+         *.for *.FOR *.fpp *.FPP *.[fF] *.[fF]90 *.[fF]95 *.[fF]03 *.[fF]08)
   endif()
   foreach(source ${sources})
     basename(name ${source})
@@ -51,7 +53,9 @@ endfunction()
 function(llvm_multisource target)
   set(sources ${ARGN})
   if(NOT sources)
-    file(GLOB sources *.c *.cpp *.cc *.f *.F *.f90 *.F90 *.f03 *.F03 *.f08 *.F08)
+    file(GLOB sources
+         *.c *.cpp *.cc
+         *.for *.FOR *.fpp *.FPP *.[fF] *.[fF]90 *.[fF]95 *.[fF]03 *.[fF]08)
   endif()
 
   llvm_test_executable_no_test(${target} ${sources})


### PR DESCRIPTION
These Fortran suffixes are aligned with [the `lookupTypeForExtension` function in `clang/lib/Driver/Types.cpp`](https://github.com/llvm/llvm-project/blob/4d6a5fc/clang/lib/Driver/Types.cpp#L299).

We Fujitsu want to contribute the [Fujitsu Compiler Test Suite](https://github.com/fujitsu/compiler-test-suite/) to the LLVM test-suite after it becomes ready and we obtain consensus in the community. It includes `*.f95` and `*.for` tests.

This commit affects tests which use `llvm_singlesource` or `llvm_multisource` in `CMakeLists.txt`. I confirmed this commit does not affect any existing tests in the LLVM test-suite.
