### PR TITLE
Fix tools tests on Windows

### DIFF
--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -1,22 +1,27 @@
 # Copy these files to the build directory so that the tests can be run even
 # without the source directory.
-configure_file(test_not.sh test_not.sh
-  @ONLY)
+configure_file(test_not.py test_not.py
+  COPYONLY)
 
-add_executable(ret1 ret1.c)
-llvm_test_run(EXECUTABLE "%b/not" "%b/test/ret1")
+llvm_test_executable_no_test(ret1 ret1.c)
+add_dependencies(ret1 not)
+llvm_test_run(EXECUTABLE "$<TARGET_FILE:not>" "$<TARGET_FILE:ret1>")
 llvm_add_test_for_target(ret1)
 
-add_executable(ret0 ret0.c)
-llvm_test_run(EXECUTABLE "%b/not" "%b/not" "%b/test/ret0")
+llvm_test_executable_no_test(ret0 ret0.c)
+add_dependencies(ret0 not)
+llvm_test_run(EXECUTABLE "$<TARGET_FILE:not>" "$<TARGET_FILE:not>" "$<TARGET_FILE:ret0>")
 llvm_add_test_for_target(ret0)
 
 # Check that expected crashes are handled correctly.
-add_executable(abrt abort.c)
-llvm_test_run(EXECUTABLE "%b/not" "--crash" "%b/test/abrt")
+llvm_test_executable_no_test(abrt abort.c)
+add_dependencies(abrt not)
+llvm_test_run(EXECUTABLE "$<TARGET_FILE:not>" "--crash" "$<TARGET_FILE:abrt>")
 llvm_add_test_for_target(abrt)
 
 # Check that not passes environment variables to the called executable.
-add_executable(check_env check_env.c)
-llvm_test_run(EXECUTABLE "/bin/bash" "%b/test/test_not.sh %b")
-llvm_add_test(test_not.test test_not.sh)
+find_package(Python COMPONENTS Interpreter)
+llvm_test_executable_no_test(check_env check_env.c)
+add_dependencies(check_env not)
+llvm_test_run(EXECUTABLE ${Python_EXECUTABLE} "%b/test/test_not.py" "$<TARGET_FILE:not>" "$<TARGET_FILE:check_env>")
+llvm_add_test_For_target(check_env)

--- a/tools/test/test_not.py
+++ b/tools/test/test_not.py
@@ -1,0 +1,7 @@
+import os
+import subprocess
+import sys
+
+os.environ["SET_IN_PARENT"] = "something"
+out = subprocess.run([sys.argv[1], sys.argv[2]])
+sys.exit(out.returncode)

--- a/tools/test/test_not.sh
+++ b/tools/test/test_not.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env sh
-#
-# USAGE: test_not.sh ${bindir}
-#
-# where bindir is ${CMAKE_BINARY_DIR}/tools
-
-export SET_IN_PARENT="something"
-$1/not $1/test/check_env


### PR DESCRIPTION
The commit 89fcc5e introduced some tests for the tools in the tools/ subdirectory that are always run, but these tests were not working on Windows due to the executables ending in .exe and one of the tests being written in bash.

This commit fixes those issues by directly using the $<TARGET_FILE> generator expressions to get the executable file names, and rewriting the bash test in python.