### PR TITLE
Always pass NO_STOP_MESSAGE to Fortran tests

### DIFF
--- a/Fortran/CMakeLists.txt
+++ b/Fortran/CMakeLists.txt
@@ -17,3 +17,5 @@ if (NOT WIN32 AND NOT APPLE)
     add_subdirectory(gfortran)
   endif()
 endif()
+
+file(COPY lit.local.cfg DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")

--- a/Fortran/Readme.txt
+++ b/Fortran/Readme.txt
@@ -1,0 +1,5 @@
+By default LLVM flang prints a stop message in certain circumstances that 
+breaks some of the tests in this directory. As such we add the environment 
+variable NO_STOP_MESSAGE=1 to disable this behaviour. If we wish to add tests
+in future that need to check the stop message, those can be added in a 
+subdirectory with a lit.local.cfg that unsets this environment variable.

--- a/Fortran/UnitTests/fcvs21_f95/lit.local.cfg
+++ b/Fortran/UnitTests/fcvs21_f95/lit.local.cfg
@@ -1,8 +1,2 @@
 config.traditional_output = True
 config.single_source = True
-
-# Flang uses NO_STOP_MESSAGE to control the output of the STOP statement. If
-# it is present in the environment, we should forward it to the tests, otherwise
-# they might choke on warnings about signaling INEXACT exceptions.
-if "NO_STOP_MESSAGE" in os.environ:
-    config.environment["NO_STOP_MESSAGE"] = os.environ["NO_STOP_MESSAGE"]

--- a/Fortran/UnitTests/finalization/lit.local.cfg
+++ b/Fortran/UnitTests/finalization/lit.local.cfg
@@ -1,8 +1,2 @@
 config.traditional_output = True
 config.single_source = True
-
-# Flang uses NO_STOP_MESSAGE to control the output of the STOP statement. If
-# it is present in the environment, we should forward it to the tests, otherwise
-# they might choke on warnings about signaling INEXACT exceptions.
-if "NO_STOP_MESSAGE" in os.environ:
-    config.environment["NO_STOP_MESSAGE"] = os.environ["NO_STOP_MESSAGE"]

--- a/Fortran/lit.local.cfg
+++ b/Fortran/lit.local.cfg
@@ -1,0 +1,4 @@
+# Flang uses NO_STOP_MESSAGE to control the output of the STOP statement.
+# We should set it for running the tests, otherwise they might choke on warnings
+# about signaling INEXACT exceptions.
+config.environment["NO_STOP_MESSAGE"] = "1"


### PR DESCRIPTION
Currently out of the box the Fortran tests fail with flang because the NO_STOP_MESSAGE environment variable needs to be set for them to pass. This environment variable should therefore always be set for the tests so that they can pass out of the box.