### PR TITLE
[Fortran/gfortran] Disable tests only on AArch64, but enable them els…

### DIFF
--- a/Fortran/gfortran/README.md
+++ b/Fortran/gfortran/README.md
@@ -312,7 +312,7 @@ In order to enable this test on cygwin, the following must be added to
     
 ```
 "chmod_1.f90":
-    enable_on: ["*-*-cygwin*"]
+    enabled_on: ["*-*-cygwin*"]
 ```
 
 Note that the string in the value of `enabled_on` exactly matches the string 

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -137,7 +137,7 @@ file(GLOB UNSUPPORTED_FILES CONFIGURE_DEPENDS
 
   # Test is not conformant: reference to f() in tobias::sub1 violates Fortran
   # 2023 (and before) 15.5.2.14 point (4). `f()` references the actual argument
-  # of `x` while `x` does not have the TARGET or POINTER attribute. 
+  # of `x` while `x` does not have the TARGET or POINTER attribute.
   aliasing_array_result_1.f90
 )
 
@@ -831,19 +831,6 @@ file(GLOB SKIPPED_FILES CONFIGURE_DEPENDS
 
   # --------------------------------------------------------------------------
   #
-  # These tests are skipped because they fail on AArch64 but not x86. These
-  # will be disabled until we allow tests to be selectively enabled on certain
-  # platforms.
-
-  large_integer_kind.f90
-  maxlocval_1.f90
-  pr91497.f90
-
-  alloc_comp_class_4.f03 # TODO: This also fails on X86, so recategorize
-  unpack_bounds_1.f90    # TODO: This also fails on X86, so recategorize
-
-  # --------------------------------------------------------------------------
-  #
   # These are skipped almost certainly because of a bug in the way multi-file
   # compile tests are built by the test-suite. This almost certainly has nothing
   # to do with flang, but they will be skipped until the test suite build
@@ -925,6 +912,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   stop_shouldfail.f90 # STOP stops program
 
   # require further analysis
+  alloc_comp_class_4.f03
   bounds_check_10.f90
   bounds_check_7.f90
   bounds_check_array_ctor_1.f90
@@ -1025,12 +1013,6 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   elemental_function_2.f90
   do_check_1.f90
   random_3.f90
-
-  # These tests fail at runtime on AArch64 (but pass on x86). Disable them
-  # anyway so the test-suite passes by default on AArch64.
-  entry_23.f
-  findloc_8.f90
-  pr99210.f90
 
   # These tests go into an infinite loop printing "Hello World"
   pointer_check_1.f90
@@ -1864,8 +1846,4 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
 
   # Tests expect semantic errors that are not raised.
   c_sizeof_7.f90
-
-  # Tests that use "PRINT namelistname"
-  namelist_print_2.f
-  print_fmt_2.f90
 )

--- a/Fortran/gfortran/regression/override.yaml
+++ b/Fortran/gfortran/regression/override.yaml
@@ -6,7 +6,7 @@
 # Please see gfortran/README.md for instructions on editing this file.
 #
 # This file is broadly divided into two. The first section contains tests that
-# are "temporarily "overridden. This are usually tests that fail on certain 
+# are "temporarily" overridden. These are usually tests that fail on certain 
 # platforms, but pass on others, but are intended to pass everywhere. When the
 # underlying issue is addressed, the tests should be removed. Eventually, there
 # should be no tests at all in this section. The second section contains tests
@@ -19,8 +19,8 @@
 
 # ------------------------ TEMPORARILY OVERRIDDEN TESTS ------------------------
 
-# findloc_8.f90 currently causes an assertion failure in SelectionDAG.cpp, but
-# only on AArch64.
+# findloc_8.f90 currently causes an assertion failure in SelectionDAG.cpp on
+# some platforms.
 #
 #     Assertion `Elt->getBitWidth() == EltVT.getSizeInBits() && "APInt size does not match type size!"' failed.
 #
@@ -29,13 +29,13 @@
 
 # entry_23.f raises a segmentation fault at runtime, but only on AArch64.
 "entry_23.f":
-  disabled_on: ["aarch64-*-*", "loongarch64-*-*"]
+  disabled_on: ["aarch64-*-*"]
 
-# pr91497.f90 fails to compile on AArch64 with the following message:
+# pr91497.f90 fails to compile on some platforms with the following message:
 # error: 'kind=' argument must be a constant scalar integer whose value is a
 # supported kind for the intrinsic result type.
 "pr91497.f90":
-  disabled_on: ["aarch64-*-*"]
+  disabled_on: ["aarch64-*-*", "loongarch64-*-*"]
 
 # maxlocval_1.f90 fails at runtime with "STOP: code 1" on AArch64. This is not
 # expected and does not occur on other targets.

--- a/Fortran/gfortran/regression/override.yaml
+++ b/Fortran/gfortran/regression/override.yaml
@@ -5,12 +5,50 @@
 #
 # Please see gfortran/README.md for instructions on editing this file.
 #
+# This file is broadly divided into two. The first section contains tests that
+# are "temporarily "overridden. This are usually tests that fail on certain 
+# platforms, but pass on others, but are intended to pass everywhere. When the
+# underlying issue is addressed, the tests should be removed. Eventually, there
+# should be no tests at all in this section. The second section contains tests
+# that are "permanently" overridden - usually because flang's behavior deviates
+# from gfortran, but we want the tests to run anyway.
+#
 # When adding a test to this file, please leave a comment describing why the
 # behavior of the test is being overridden.
 
-# The following two tests use ```print <namelist name>```. This is a
-# non-standard extension that is not supported in certain cases in gfortran,
-# but, for now, is always supported in flang,
+
+# ------------------------ TEMPORARILY OVERRIDDEN TESTS ------------------------
+
+# findloc_8.f90 currently causes an assertion failure in SelectionDAG.cpp, but
+# only on AArch64.
+#
+#     Assertion `Elt->getBitWidth() == EltVT.getSizeInBits() && "APInt size does not match type size!"' failed.
+#
+"findloc_8.f90":
+  disabled_on: ["aarch64-*-*"]
+
+# entry_23.f raises a segmentation fault at runtime, but only on AArch64.
+"entry_23.f":
+  disabled_on: ["aarch64-*-*"]
+
+# pr91497.f90 fails to compile on AArch64 with the following message:
+# error: 'kind=' argument must be a constant scalar integer whose value is a
+# supported kind for the intrinsic result type.
+"pr91497.f90":
+  disabled_on: ["aarch64-*-*"]
+
+# maxlocval_1.f90 fails at runtime with "STOP: code 1" on AArch64. This is not
+# expected and does not occur on other targets.
+"maxlocval_1.f90":
+  disabled_on: ["aarch64-*-*"]
+
+  
+# ------------------------ PERMANENTLY OVERRIDDEN TESTS ------------------------
+
+# namelist_print_2.f and print_fmt_2.f90 use ```print <namelist name>```. This
+# is a non-standard extension that is not supported in certain cases in
+# gfortran, but is always supported in flang.
+
 "namelist_print_2.f":
   xfail: false
 

--- a/Fortran/gfortran/regression/override.yaml
+++ b/Fortran/gfortran/regression/override.yaml
@@ -25,11 +25,11 @@
 #     Assertion `Elt->getBitWidth() == EltVT.getSizeInBits() && "APInt size does not match type size!"' failed.
 #
 "findloc_8.f90":
-  disabled_on: ["aarch64-*-*"]
+  disabled_on: ["aarch64-*-*", "loongarch64-*-*"]
 
 # entry_23.f raises a segmentation fault at runtime, but only on AArch64.
 "entry_23.f":
-  disabled_on: ["aarch64-*-*"]
+  disabled_on: ["aarch64-*-*", "loongarch64-*-*"]
 
 # pr91497.f90 fails to compile on AArch64 with the following message:
 # error: 'kind=' argument must be a constant scalar integer whose value is a

--- a/Fortran/gfortran/regression/override.yaml
+++ b/Fortran/gfortran/regression/override.yaml
@@ -25,17 +25,17 @@
 #     Assertion `Elt->getBitWidth() == EltVT.getSizeInBits() && "APInt size does not match type size!"' failed.
 #
 "findloc_8.f90":
-  disabled_on: ["aarch64-*-*", "loongarch64-*-*"]
+  disabled_on: ["aarch64-*-*", "loongarch64-*-*", "ppc64le-*-*"]
 
 # entry_23.f raises a segmentation fault at runtime, on some platforms.
 "entry_23.f":
-  disabled_on: ["aarch64-*-*", "loongarch64-*-*"]
+  disabled_on: ["aarch64-*-*", "loongarch64-*-*", "ppc64le-*-*"]
 
 # pr91497.f90 fails to compile on some platforms with the following message:
 # error: 'kind=' argument must be a constant scalar integer whose value is a
 # supported kind for the intrinsic result type.
 "pr91497.f90":
-  disabled_on: ["aarch64-*-*", "loongarch64-*-*"]
+  disabled_on: ["aarch64-*-*", "loongarch64-*-*", "ppc64le-*-*"]
 
 # maxlocval_1.f90 fails at runtime with "STOP: code 1" on AArch64. This is not
 # expected and does not occur on other targets.

--- a/Fortran/gfortran/regression/override.yaml
+++ b/Fortran/gfortran/regression/override.yaml
@@ -27,9 +27,9 @@
 "findloc_8.f90":
   disabled_on: ["aarch64-*-*", "loongarch64-*-*"]
 
-# entry_23.f raises a segmentation fault at runtime, but only on AArch64.
+# entry_23.f raises a segmentation fault at runtime, on some platforms.
 "entry_23.f":
-  disabled_on: ["aarch64-*-*"]
+  disabled_on: ["aarch64-*-*", "loongarch64-*-*"]
 
 # pr91497.f90 fails to compile on some platforms with the following message:
 # error: 'kind=' argument must be a constant scalar integer whose value is a

--- a/Fortran/gfortran/regression/tests.cmake
+++ b/Fortran/gfortran/regression/tests.cmake
@@ -2671,7 +2671,7 @@ compile;pr91372.f90;;;;
 compile;pr91471.f90;;;;
 compile;pr91485.f90;;;;
 compile;pr91496.f90;;-fdump-tree-original;;
-compile;pr91497.f90;;-Wall;;aarch64-*-* loongarch64-*-*
+compile;pr91497.f90;;-Wall;;aarch64-.+-.+ loongarch64-.+-.+
 compile;pr91497_2.f90;;-Wall;;
 compile;pr91564.f90;xfail;;;
 compile;pr91565.f90;xfail;;;
@@ -4701,7 +4701,7 @@ run;entry_12.f90;;;;
 run;entry_13.f90;;;;
 run;entry_14.f90;;;;
 run;entry_16.f90;;;;
-run;entry_23.f;;;;aarch64-*-* loongarch64-*-*
+run;entry_23.f;;;;aarch64-.+-.+ loongarch64-.+-.+
 run;entry_26.f90;;-fno-f2c;;
 run;entry_27.f90;;-ff2c;;
 run;entry_3.f90;;;;
@@ -4806,7 +4806,7 @@ run;findloc_3.f90;;;;
 run;findloc_4.f90;;;;
 run;findloc_5.f90;;;;
 run;findloc_6.f90;;;;
-run;findloc_8.f90;;;;aarch64-*-* loongarch64-*-*
+run;findloc_8.f90;;;;aarch64-.+-.+ loongarch64-.+-.+
 run;float_1.f90;;;;
 run;flush_1.f90;;;;
 run;fmt_bz_bn.f;;;;
@@ -5248,7 +5248,7 @@ run;maxloc_bounds_6.f90;xfail;-fbounds-check;;
 run;maxloc_bounds_7.f90;xfail;-fbounds-check;;
 run;maxloc_bounds_8.f90;xfail;-fbounds-check;;
 run;maxloc_string_1.f90;;;;
-run;maxlocval_1.f90;;;;aarch64-*-*
+run;maxlocval_1.f90;;;;aarch64-.+-.+
 run;maxlocval_2.f90;;;;
 run;maxlocval_3.f90;;;;
 run;maxlocval_4.f90;;;;

--- a/Fortran/gfortran/regression/tests.cmake
+++ b/Fortran/gfortran/regression/tests.cmake
@@ -2671,7 +2671,7 @@ compile;pr91372.f90;;;;
 compile;pr91471.f90;;;;
 compile;pr91485.f90;;;;
 compile;pr91496.f90;;-fdump-tree-original;;
-compile;pr91497.f90;;-Wall;;aarch64-*-*
+compile;pr91497.f90;;-Wall;;aarch64-*-* loongarch64-*-*
 compile;pr91497_2.f90;;-Wall;;
 compile;pr91564.f90;xfail;;;
 compile;pr91565.f90;xfail;;;

--- a/Fortran/gfortran/regression/tests.cmake
+++ b/Fortran/gfortran/regression/tests.cmake
@@ -44,6 +44,7 @@ preprocess;warning-directive-2.F90;xfail;-std=f95 -fdiagnostics-show-option -Wer
 preprocess;warning-directive-3.F90;;-std=f95 -fdiagnostics-show-option -Werror -Wno-error=cpp;;
 preprocess;warning-directive-4.F90;;-std=f95 -fdiagnostics-show-option -Wno-cpp;;
 assemble;module_naming_1.f90;;;;
+assemble;pr88833.f90;;-O3 -march=armv8.2-a+sve --save-temps;;
 assemble;same_name_1.f90;;;;
 compile;20181025-1.f;;-Ofast;;
 compile;20231103-1.f90;;-Ofast;;
@@ -2635,7 +2636,6 @@ compile;pr88379.f90;;-fcoarray=single;;
 compile;pr88467.f90;xfail;;;
 compile;pr88552.f90;xfail;;;
 compile;pr88624.f90;;-fcoarray=lib;;
-compile;pr88833.f90;;-O3 -march=armv8.2-a+sve --save-temps;;
 compile;pr88902.f90;;-flto --param ggc-min-heapsize=0;;
 compile;pr88932.f90;;-O1 -fpredictive-commoning -fno-tree-ch -fno-tree-dominator-opts -fno-tree-fre;;
 compile;pr88934.f90;;-O -ftree-vectorize;;
@@ -2671,7 +2671,7 @@ compile;pr91372.f90;;;;
 compile;pr91471.f90;;;;
 compile;pr91485.f90;;;;
 compile;pr91496.f90;;-fdump-tree-original;;
-compile;pr91497.f90;;-Wall;;
+compile;pr91497.f90;;-Wall;;aarch64-*-*
 compile;pr91497_2.f90;;-Wall;;
 compile;pr91564.f90;xfail;;;
 compile;pr91565.f90;xfail;;;
@@ -4701,7 +4701,7 @@ run;entry_12.f90;;;;
 run;entry_13.f90;;;;
 run;entry_14.f90;;;;
 run;entry_16.f90;;;;
-run;entry_23.f;;;;
+run;entry_23.f;;;;aarch64-*-*
 run;entry_26.f90;;-fno-f2c;;
 run;entry_27.f90;;-ff2c;;
 run;entry_3.f90;;;;
@@ -4806,7 +4806,7 @@ run;findloc_3.f90;;;;
 run;findloc_4.f90;;;;
 run;findloc_5.f90;;;;
 run;findloc_6.f90;;;;
-run;findloc_8.f90;;;;
+run;findloc_8.f90;;;;aarch64-*-*
 run;float_1.f90;;;;
 run;flush_1.f90;;;;
 run;fmt_bz_bn.f;;;;
@@ -5248,7 +5248,7 @@ run;maxloc_bounds_6.f90;xfail;-fbounds-check;;
 run;maxloc_bounds_7.f90;xfail;-fbounds-check;;
 run;maxloc_bounds_8.f90;xfail;-fbounds-check;;
 run;maxloc_string_1.f90;;;;
-run;maxlocval_1.f90;;;;
+run;maxlocval_1.f90;;;;aarch64-*-*
 run;maxlocval_2.f90;;;;
 run;maxlocval_3.f90;;;;
 run;maxlocval_4.f90;;;;

--- a/Fortran/gfortran/regression/tests.cmake
+++ b/Fortran/gfortran/regression/tests.cmake
@@ -2671,7 +2671,7 @@ compile;pr91372.f90;;;;
 compile;pr91471.f90;;;;
 compile;pr91485.f90;;;;
 compile;pr91496.f90;;-fdump-tree-original;;
-compile;pr91497.f90;;-Wall;;aarch64-.+-.+ loongarch64-.+-.+
+compile;pr91497.f90;;-Wall;;aarch64-.+-.+ loongarch64-.+-.+ ppc64le-.+-.+
 compile;pr91497_2.f90;;-Wall;;
 compile;pr91564.f90;xfail;;;
 compile;pr91565.f90;xfail;;;
@@ -4701,7 +4701,7 @@ run;entry_12.f90;;;;
 run;entry_13.f90;;;;
 run;entry_14.f90;;;;
 run;entry_16.f90;;;;
-run;entry_23.f;;;;aarch64-.+-.+ loongarch64-.+-.+
+run;entry_23.f;;;;aarch64-.+-.+ loongarch64-.+-.+ ppc64le-.+-.+
 run;entry_26.f90;;-fno-f2c;;
 run;entry_27.f90;;-ff2c;;
 run;entry_3.f90;;;;
@@ -4806,7 +4806,7 @@ run;findloc_3.f90;;;;
 run;findloc_4.f90;;;;
 run;findloc_5.f90;;;;
 run;findloc_6.f90;;;;
-run;findloc_8.f90;;;;aarch64-.+-.+ loongarch64-.+-.+
+run;findloc_8.f90;;;;aarch64-.+-.+ loongarch64-.+-.+ ppc64le-.+-.+
 run;float_1.f90;;;;
 run;flush_1.f90;;;;
 run;fmt_bz_bn.f;;;;

--- a/Fortran/gfortran/regression/tests.cmake
+++ b/Fortran/gfortran/regression/tests.cmake
@@ -4701,7 +4701,7 @@ run;entry_12.f90;;;;
 run;entry_13.f90;;;;
 run;entry_14.f90;;;;
 run;entry_16.f90;;;;
-run;entry_23.f;;;;aarch64-*-*
+run;entry_23.f;;;;aarch64-*-* loongarch64-*-*
 run;entry_26.f90;;-fno-f2c;;
 run;entry_27.f90;;-ff2c;;
 run;entry_3.f90;;;;
@@ -4806,7 +4806,7 @@ run;findloc_3.f90;;;;
 run;findloc_4.f90;;;;
 run;findloc_5.f90;;;;
 run;findloc_6.f90;;;;
-run;findloc_8.f90;;;;aarch64-*-*
+run;findloc_8.f90;;;;aarch64-*-* loongarch64-*-*
 run;float_1.f90;;;;
 run;flush_1.f90;;;;
 run;fmt_bz_bn.f;;;;

--- a/Fortran/gfortran/utils/update-test-config.py
+++ b/Fortran/gfortran/utils/update-test-config.py
@@ -108,7 +108,7 @@ tgt = f'({pfx}target[ ]*(?P<target>.+){sfx})?'
 
 re_btxt = re.compile('[{][ ]*(.+?)[ ]*[}]')
 re_fortran = re.compile('^.+[.][Ff].*$')
-re_assemble = re.compile(f'{pfx}dg-(lto-)?do[ ]*assemble{sfx}')
+re_assemble = re.compile(f'{pfx}dg-(lto-)?do[ ]*assemble[ ]*{tgt}{sfx}')
 re_preprocess = re.compile(f'{pfx}dg-do[ ]*preprocess{sfx}')
 re_compile = re.compile(f'{pfx}dg-do[ ]*compile[ ]*{tgt}{sfx}')
 re_link = re.compile(f'{pfx}dg-(lto-)?do[ ]*link[ ]*{tgt}{sfx}')


### PR DESCRIPTION
…ewhere

Some tests fail only on AArch64, but pass on other platforms. Previously, these were disabled everywhere, but now they can be disabled only on AArch64 and enabled on other platforms. In addition, some tests that were failing only on AArch64 now pass, so they are enabled everywhere.

The static test configuration has also been updated to reflect these changes. Some bugs were exposed in the update script during this process. These have also been fixed.

----------------------------------------------------------------------------------------
@ylzsx, 

Since these tests were preciously disabled on LoongArch, could you check that they pass there. If they do not, I will update the PR to disable them on LoongArch as well.
