### PR TITLE
[SingleSource][Regressions][C] Fix loop-15.c so it does not trigger UB.

### DIFF
--- a/SingleSource/Regression/C/gcc-c-torture/execute/loop-15.c
+++ b/SingleSource/Regression/C/gcc-c-torture/execute/loop-15.c
@@ -3,10 +3,11 @@
 void
 foo (unsigned long *start, unsigned long *end)
 {
-  unsigned long *temp = end - 1;
-
-  while (end > start)
-    *end-- = *temp--;
+  while (end > start) 
+  {
+    *end = *(end - 1);
+	--end;
+  }
 }
 
 int

--- a/SingleSource/Regression/C/gcc-c-torture/execute/loop-15.c
+++ b/SingleSource/Regression/C/gcc-c-torture/execute/loop-15.c
@@ -6,7 +6,7 @@ foo (unsigned long *start, unsigned long *end)
   while (end > start) 
   {
     *end = *(end - 1);
-	--end;
+    --end;
   }
 }
 


### PR DESCRIPTION
In the first iteration, we get `foo(a, a)`, which produces an OOB pointer at `temp`.