### PR TITLE
[Fortran/gfortran] Disable bounds-check tests.

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1627,8 +1627,16 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   # Tests looking for runtime errors (e.g., bound checks). Correctly
   # caught by flang runtime, but not caught with Flang optimizations,
   # e.g. due to intrinsics inlining. These can pass with -O0:
+  all_bounds_1.f90
   cshift_bounds_3.f90
   cshift_bounds_4.f90
+  maxloc_bounds_1.f90
+  maxloc_bounds_2.f90
+  maxloc_bounds_4.f90
+  maxloc_bounds_8.f90
+  maxloc_bounds_7.f90
+  pack_bounds_1.f90
+  spread_bounds_1.f90
 
   # Bad test, assigning an 11 elements array to a 12 elements array.
   transfer_array_intrinsic_4.f90

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1626,7 +1626,9 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
 
   # Tests looking for runtime errors (e.g., bound checks). Correctly
   # caught by flang runtime, but not caught with Flang optimizations,
-  # e.g. due to intrinsics inlining. These can pass with -O0:
+  # e.g. due to intrinsics inlining.
+  # Until https://github.com/orgs/llvm/projects/12?pane=issue&itemId=29048733
+  # is implemented, they can only pass at -O0:
   all_bounds_1.f90
   cshift_bounds_3.f90
   cshift_bounds_4.f90


### PR DESCRIPTION
The tests started failing at -O2 after https://github.com/llvm/llvm-project/pull/121544
Flang inlines hlfir.assign with hlfir.expr RHSs after the change,
so the runtime is not called, and it does not make the bounds checks.
Related feature request: https://github.com/orgs/llvm/projects/12?pane=issue&itemId=29048733
