### PR TITLE
[Microbench] Sync with google/benchmark to change FindPFM.cmake

### DIFF
--- a/MicroBenchmarks/libs/benchmark/cmake/Modules/FindPFM.cmake
+++ b/MicroBenchmarks/libs/benchmark/cmake/Modules/FindPFM.cmake
@@ -11,7 +11,7 @@ set_package_properties(PFM PROPERTIES
                        DESCRIPTION "a helper library to develop monitoring tools"
                        PURPOSE "Used to program specific performance monitoring events")
 
-check_library_exists(libpfm.a pfm_initialize "" HAVE_LIBPFM_INITIALIZE)
+check_library_exists(pfm pfm_initialize "" HAVE_LIBPFM_INITIALIZE)
 if(HAVE_LIBPFM_INITIALIZE)
   check_include_file(perfmon/perf_event.h HAVE_PERFMON_PERF_EVENT_H)
   check_include_file(perfmon/pfmlib.h HAVE_PERFMON_PFMLIB_H)

--- a/MicroBenchmarks/libs/benchmark/cmake/Modules/FindPFM.cmake
+++ b/MicroBenchmarks/libs/benchmark/cmake/Modules/FindPFM.cmake
@@ -1,26 +1,33 @@
 # If successful, the following variables will be defined:
-# HAVE_LIBPFM.
-# Set BENCHMARK_ENABLE_LIBPFM to 0 to disable, regardless of libpfm presence.
-include(CheckIncludeFile)
-include(CheckLibraryExists)
+# PFM_FOUND.
+# PFM_LIBRARIES
+# PFM_INCLUDE_DIRS
+# the following target will be defined:
+# PFM::libpfm
+
 include(FeatureSummary)
-enable_language(C)
+include(FindPackageHandleStandardArgs)
 
 set_package_properties(PFM PROPERTIES
                        URL http://perfmon2.sourceforge.net/
-                       DESCRIPTION "a helper library to develop monitoring tools"
+                       DESCRIPTION "A helper library to develop monitoring tools"
                        PURPOSE "Used to program specific performance monitoring events")
 
-check_library_exists(pfm pfm_initialize "" HAVE_LIBPFM_INITIALIZE)
-if(HAVE_LIBPFM_INITIALIZE)
-  check_include_file(perfmon/perf_event.h HAVE_PERFMON_PERF_EVENT_H)
-  check_include_file(perfmon/pfmlib.h HAVE_PERFMON_PFMLIB_H)
-  check_include_file(perfmon/pfmlib_perf_event.h HAVE_PERFMON_PFMLIB_PERF_EVENT_H)
-  if(HAVE_PERFMON_PERF_EVENT_H AND HAVE_PERFMON_PFMLIB_H AND HAVE_PERFMON_PFMLIB_PERF_EVENT_H)
+find_library(PFM_LIBRARY NAMES pfm)
+find_path(PFM_INCLUDE_DIR NAMES perfmon/pfmlib.h)
+
+find_package_handle_standard_args(PFM REQUIRED_VARS PFM_LIBRARY PFM_INCLUDE_DIR)
+
+if (PFM_FOUND AND NOT TARGET PFM::libpfm)
+    add_library(PFM::libpfm UNKNOWN IMPORTED)
+    set_target_properties(PFM::libpfm PROPERTIES
+        IMPORTED_LOCATION "${PFM_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${PFM_INCLUDE_DIR}")
     message("Using Perf Counters.")
     set(HAVE_LIBPFM 1)
     set(PFM_FOUND 1)
-  endif()
 else()
-  message("Perf Counters support requested, but was unable to find libpfm.")
+    message("Perf Counters support requested, but was unable to find libpfm.")
 endif()
+
+mark_as_advanced(PFM_LIBRARY PFM_INCLUDE_DIR)


### PR DESCRIPTION
libpfm only contains dynamic library in some of our environments. Since we don't actually static link them, only find dynamic library is enough. This also aligns with LLVM's configuration

https://github.com/llvm/llvm-project/blob/7d5376270ae5807a29597a91d7cf59f967ccf39e/llvm/cmake/modules/FindLibpfm.cmake#L13

Cherry-picked from: https://github.com/google/benchmark/commit/a092f8222c1fa95986efe611abf78daba59d3c59