### PR TITLE
[SPEC2017] Do not add bwaves_[34].in inputs under "speed" suite type

### DIFF
--- a/External/SPEC/CFP2017rate/503.bwaves_r/CMakeLists.txt
+++ b/External/SPEC/CFP2017rate/503.bwaves_r/CMakeLists.txt
@@ -48,18 +48,21 @@ speccpu2017_run_test(
   RUN_TYPE ref
 )
 
-speccpu2017_run_test(
-  < "${RUN_ref_DIR_REL}/bwaves_3.in"
-  STDOUT bwaves_3.out
-  RUN_TYPE ref
-)
+if (BENCHMARK_SUITE_TYPE STREQUAL "rate")
 
-speccpu2017_run_test(
-  < "${RUN_ref_DIR}/bwaves_4.in"
-  STDOUT bwaves_4.out
-  RUN_TYPE ref
-)
+  speccpu2017_run_test(
+    < "${RUN_ref_DIR_REL}/bwaves_3.in"
+    STDOUT bwaves_3.out
+    RUN_TYPE ref
+  )
 
+  speccpu2017_run_test(
+    < "${RUN_ref_DIR}/bwaves_4.in"
+    STDOUT bwaves_4.out
+    RUN_TYPE ref
+  )
+
+endif()
 
 ################################################################################
 


### PR DESCRIPTION
Do not run 603.bwaves_s on the bwaves_3.in and bwaves_4.in inputs under the reference input size. The speed data dir for 603.bwaves_s does not contain bwaves_3.in and bwaves_4.in, resulting in test failures when running 603.bwaves_s with llvm-lit.