### PR TITLE
[Fortran/gfortran] Disable test on AIX

### DIFF
--- a/Fortran/gfortran/regression/override.yaml
+++ b/Fortran/gfortran/regression/override.yaml
@@ -180,6 +180,10 @@
 "scalar_mask_2.f90":
   disabled_on: ["powerpc-*-aix"]
 
+# libm's routine lround returns incorrect values on AIX
+"nint_2.f90":
+  disabled_on: ["powerpc-*-aix"]
+
 # ------------------------ PERMANENTLY OVERRIDDEN TESTS ------------------------
 
 # namelist_print_2.f and print_fmt_2.f90 use ```print <namelist name>```. This

--- a/Fortran/gfortran/regression/tests.cmake
+++ b/Fortran/gfortran/regression/tests.cmake
@@ -5450,7 +5450,7 @@ run;newunit_1.f90;;;;
 run;newunit_3.f90;;;;
 run;newunit_5.f90;;;;
 run;nint_1.f90;;;;
-run;nint_2.f90;;;;
+run;nint_2.f90;;;;powerpc-.+-aix
 run;no-automatic.f90;;-fno-automatic;;
 run;no_arg_check_2a.f90;;;;
 run;no_range_check_1.f90;;-fno-range-check -O0;;


### PR DESCRIPTION
The libm routine, `lround`, gives wrong result. This test is disabled temporarily.