### PR TITLE
Fix UB in pops.c

### DIFF
--- a/MultiSource/Benchmarks/MallocBench/cfrac/pops.c
+++ b/MultiSource/Benchmarks/MallocBench/cfrac/pops.c
@@ -91,10 +91,11 @@ precision palloc(size)
    register posit size;
 {
    register precision w;
-   register cacheType *kludge = pcache + size;	/* for shitty compilers */
+   register cacheType *kludge;  /* for shitty compilers */
 
 #if !(defined(NOMEMOPT) || defined(BWGC))
-   if (size < CACHESIZE && (w = kludge->next) != pUndef) {
+   if (size < CACHESIZE && (kludge = pcache + size) &&
+       (w = kludge->next) != pUndef) {
       kludge->next = ((cacheType *) w)->next;
       --kludge->count;
    } else {
@@ -135,9 +136,9 @@ int pfree(u)
 
    size = u->alloc;
 
-   kludge = pcache + size;
 #if !(defined(NOMEMOPT) || defined(BWGC))
-   if (size < CACHESIZE && kludge->count < CACHELIMIT) {
+   if (size < CACHESIZE && (kludge = pcache + size) &&
+       kludge->count < CACHELIMIT) {
       ((cacheType *) u)->next = kludge->next;
       kludge->next = u;
       kludge->count++;


### PR DESCRIPTION
It is undefined behaviour to construct a pointer that is out-of-bounds, not just to use it.

Cherry-pick of commit in mimalloc-bench:
https://github.com/daanx/mimalloc-bench/commit/b517ae367c186be7365d238806b475478637d8f2