### PR TITLE
[utils] Fix Warning: Series.__getitem__ treating keys as positions  is deprecated

### DIFF
--- a/utils/compare.py
+++ b/utils/compare.py
@@ -203,7 +203,7 @@ def truncate(string, prefix_len, suffix_len):
 def determine_common_prefix_suffix(names, min_len=8):
     if len(names) <= 1:
         return (0, 0)
-    name0 = names[0]
+    name0 = names.iloc[0]
     prefix = name0
     prefix_len = len(name0)
     suffix = name0


### PR DESCRIPTION
warning log:
```
./utils/compare.py:206: FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
  name0 = names[0]
```