### PR TITLE
[Prolangs-C] Fix compilation errors with clang 15 and above

### DIFF
--- a/MultiSource/Benchmarks/Prolangs-C/assembler/sym_tab.h
+++ b/MultiSource/Benchmarks/Prolangs-C/assembler/sym_tab.h
@@ -49,6 +49,6 @@ extern struct SYMBOL_TABLE_ENTRY *LOOK_UP_SYMBOL();
 /* If <MODULE,LABEL> pair is not in the symbol table, put it there and       */
 /* TRUE (integer 1). Otherwise return FALSE (integer 0).                     */
 /* Puts onto front of the linked list.                                       */
-extern int INSERT_IN_SYM_TAB();
+extern int INSERT_IN_SYM_TAB(char *, char *, int, enum kind, SYMBOL_TABLE *);
 
 

--- a/MultiSource/Benchmarks/Prolangs-C/loader/sym_tab.h
+++ b/MultiSource/Benchmarks/Prolangs-C/loader/sym_tab.h
@@ -49,6 +49,6 @@ extern struct SYMBOL_TABLE_ENTRY *LOOK_UP_SYMBOL();
 /* If <MODULE,LABEL> pair is not in the symbol table, put it there and       */
 /* TRUE (integer 1). Otherwise return FALSE (integer 0).                     */
 /* Puts onto front of the linked list.                                       */
-extern int INSERT_IN_SYM_TAB();
+extern int INSERT_IN_SYM_TAB(char *, char *, int, enum kind, SYMBOL_TABLE *);
 
 


### PR DESCRIPTION
Correcting these function declarations addresses these compilation errors:

```
llvm-test-suite/MultiSource/Benchmarks/Prolangs-C/loader/sym_tab.c:40:5: error: conflicting types for 'INSERT_IN_SYM_TAB'
   40 | int INSERT_IN_SYM_TAB(char *MODULE,char *LABEL,int LOCATION,enum kind TYPE,
      |     ^
llvm-test-suite/MultiSource/Benchmarks/Prolangs-C/loader/sym_tab.h:52:12: note: previous declaration is here
   52 | extern int INSERT_IN_SYM_TAB();
      |            ^
1 error generated.

llvm-test-suite/MultiSource/Benchmarks/Prolangs-C/assembler/sym_tab.c:40:5: error: conflicting types for 'INSERT_IN_SYM_TAB'
   40 | int INSERT_IN_SYM_TAB(char *MODULE,char *LABEL,int LOCATION,enum kind TYPE,
      |     ^
llvm-test-suite/MultiSource/Benchmarks/Prolangs-C/assembler/sym_tab.h:52:12: note: previous declaration is here
   52 | extern int INSERT_IN_SYM_TAB();
      |            ^
1 error generated.
```


Since clang 15.x, this has been an error for C programs.