### PR TITLE
[flang] Enable FSEEK & FTELL tests

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -33,10 +33,6 @@ file(GLOB UNSUPPORTED_FILES CONFIGURE_DEPENDS
   dec_io_2a.f90                   # fseek
   fgetc_1.f90                     # fgetc, fputc
   fgetc_2.f90                     # fgetc, fputc
-  fseek.f90                       # fseek
-  ftell_1.f90                     # ftell
-  ftell_2.f90                     # ftell
-  ftell_3.f90                     # ftell
   inquire_10.f90                  # getcwd
   int_conv_1.f90                  # int2, int8
   itime_idate_1.f                 # itime, idate
@@ -1870,4 +1866,9 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
 
   # Tests expect semantic errors that are not raised.
   c_sizeof_7.f90
+
+  # We allow USE association of a subprogram's name into its scope, with a portability
+  # warning, so long as it is not used in that scope.
+  use_15.f90
+  use_rename_8.f90
 )


### PR DESCRIPTION
Once LLVM PR https://github.com/llvm/llvm-project/pull/133003 merges, these tests can be enabled.