### PR TITLE
[Fortran] disable pointer_check_11.f90 which exhibits UB

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1046,7 +1046,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   namelist_96.f90 # real data for integer NAMELIST input
   no_unit_error_1.f90
   pointer_check_10.f90
-  pointer_check_11.f90
+  pointer_check_11.f90 # test exhibits UB, sometimes at O3 it hangs forever
   pointer_remapping_6.f08
   unpack_bounds_1.f90
 

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1046,6 +1046,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   namelist_96.f90 # real data for integer NAMELIST input
   no_unit_error_1.f90
   pointer_check_10.f90
+  pointer_check_11.f90
   pointer_remapping_6.f08
   unpack_bounds_1.f90
 


### PR DESCRIPTION
This test calls an empty subroutine with a null pointer as an argument. In gfortran it is hoped that a flag will detect this and produce an error. Flang does not perform any such analysis, and so on some machines when optimization is enabled, this test never terminates. I don't think this is a flang bug as such because the input code is doing undefined behavior.