### PR TITLE
Fix UB in MallocBench/gs/interp.c

### DIFF
--- a/MultiSource/Benchmarks/MallocBench/gs/interp.c
+++ b/MultiSource/Benchmarks/MallocBench/gs/interp.c
@@ -47,7 +47,7 @@ private op_proc_(interp_exit);
 #define os_guard_under 10
 #define os_guard_over 10
 private ref ostack[os_guard_under+max_ostack+os_guard_over];
-ref estack[max_estack];
+ref estack[max_estack + 1];
 ref dstack[max_dstack];
 ref *osp_nargs[os_max_nargs];		/* for checking osp */
 
@@ -107,7 +107,7 @@ interp_init(int ndict)
 		for ( i = 1; i < os_max_nargs; i++ )
 			osp_nargs[i] = osbot + i - 1;
 	   }
-	esp = estack - 1, estop = estack + (max_estack-1);
+	esp = estack, estop = estack + max_estack;
 	/* Initialize the dictionary stack to the first ndict */
 	/* dictionaries.  ndict is a parameter because during */
 	/* initialization, only systemdict exists. */


### PR DESCRIPTION
It is undefined behaviour to construct a pointer that is out-of-bounds, not just to use it.

This is a follow-up to commit 9391cd9f62276f019929761d1837791eb53f193e which fixed the same problem (detected by -fsanitize=array-bounds) in MallocBench/cfrac.