### PR TITLE
[Fortran/gfortran] Disable bounds-check tests for maxloc.

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1645,7 +1645,9 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   matmul_bounds_9.f90
   maxloc_bounds_1.f90
   maxloc_bounds_2.f90
+  maxloc_bounds_3.f90
   maxloc_bounds_4.f90
+  maxloc_bounds_6.f90
   maxloc_bounds_7.f90
   maxloc_bounds_8.f90
   pack_bounds_1.f90


### PR DESCRIPTION
The tests will start failing at -O2 when I merge
https://github.com/llvm/llvm-project/pull/136071
The HLFIR inlining does not perform the bounds check.
