### PR TITLE
[SPEC] Workaround error with latest clang in 523.xalancbmk_r

### DIFF
--- a/External/SPEC/CINT2006/483.xalancbmk/CMakeLists.txt
+++ b/External/SPEC/CINT2006/483.xalancbmk/CMakeLists.txt
@@ -14,6 +14,11 @@ add_definitions(
 
 list(APPEND CXXFLAGS -std=gnu++98)
 
+# Workaround undefined behaviour in xerces-c dependency.
+# This is fixed upstream but not included in SPEC CPU 2017:
+# https://github.com/apache/xerces-c/commit/02e48494496dd24476490fd36c1bc97b6a37002e#diff-e2f4677367dcf43bd6d31b2bbca5b1aa89e36ec155a040fe4447b201a554cf81
+add_compile_options(-fwrapv-pointer)
+
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-fdelayed-template-parsing
                         HAVE_CXX_FLAG_FDELAYED_TEMPLATE_PARSING)

--- a/External/SPEC/CINT2017rate/523.xalancbmk_r/CMakeLists.txt
+++ b/External/SPEC/CINT2017rate/523.xalancbmk_r/CMakeLists.txt
@@ -8,6 +8,11 @@ speccpu2017_benchmark(RATE)
 
 set(CMAKE_CXX_STANDARD 14)
 
+# Workaround undefined behaviour in xerces-c dependency.
+# This is fixed upstream but not included in SPEC CPU 2017:
+# https://github.com/apache/xerces-c/commit/02e48494496dd24476490fd36c1bc97b6a37002e#diff-e2f4677367dcf43bd6d31b2bbca5b1aa89e36ec155a040fe4447b201a554cf81
+add_compile_options(-fwrapv-pointer)
+
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-fdelayed-template-parsing
                         HAVE_CXX_FLAG_FDELAYED_TEMPLATE_PARSING)


### PR DESCRIPTION
523.xalancbmk_r has some code that calculates the offset of a member, but is undefined behaviour.

After https://github.com/llvm/llvm-project/pull/130742 this is now optimized away which results in a miscompile.

This has been fixed in upstream versions of xerces-c, but not yet in SPEC CPU 2017: https://github.com/apache/xerces-c/commit/02e48494496dd24476490fd36c1bc97b6a37002e#diff-e2f4677367dcf43bd6d31b2bbca5b1aa89e36ec155a040fe4447b201a554cf81

This patch passes -fwrapv-pointer to 523.xalancbmk_r to work around it for now. Ideally SPEC CPU 2017 will issue an update which fixes this issue and we can drop this flag.

I've included it in the 2006 benchmark too for good measure, although I haven't tried it out, see 92b58b3bf4c6001bff4c7c7f8f98305e3ead56ff
