### PR TITLE
[SPEC] Add compiler check for -fwrapv-pointer in xalancbmk

### DIFF
--- a/External/SPEC/CINT2006/483.xalancbmk/CMakeLists.txt
+++ b/External/SPEC/CINT2006/483.xalancbmk/CMakeLists.txt
@@ -14,12 +14,17 @@ add_definitions(
 
 list(APPEND CXXFLAGS -std=gnu++98)
 
+include(CheckCXXCompilerFlag)
+
 # Workaround undefined behaviour in xerces-c dependency.
 # This is fixed upstream but not included in SPEC CPU 2017:
 # https://github.com/apache/xerces-c/commit/02e48494496dd24476490fd36c1bc97b6a37002e#diff-e2f4677367dcf43bd6d31b2bbca5b1aa89e36ec155a040fe4447b201a554cf81
-add_compile_options(-fwrapv-pointer)
+check_cxx_compiler_flag(-fwrapv-pointer
+                        HAVE_CXX_FLAG_FWRAPV_POINTER)
+if(HAVE_CXX_FLAG_FWRAPV_POINTER)
+  add_compile_options(-fwrapv-pointer)
+endif()
 
-include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-fdelayed-template-parsing
                         HAVE_CXX_FLAG_FDELAYED_TEMPLATE_PARSING)
 if(HAVE_CXX_FLAG_FDELAYED_TEMPLATE_PARSING)

--- a/External/SPEC/CINT2017rate/523.xalancbmk_r/CMakeLists.txt
+++ b/External/SPEC/CINT2017rate/523.xalancbmk_r/CMakeLists.txt
@@ -8,12 +8,17 @@ speccpu2017_benchmark(RATE)
 
 set(CMAKE_CXX_STANDARD 14)
 
+include(CheckCXXCompilerFlag)
+
 # Workaround undefined behaviour in xerces-c dependency.
 # This is fixed upstream but not included in SPEC CPU 2017:
 # https://github.com/apache/xerces-c/commit/02e48494496dd24476490fd36c1bc97b6a37002e#diff-e2f4677367dcf43bd6d31b2bbca5b1aa89e36ec155a040fe4447b201a554cf81
-add_compile_options(-fwrapv-pointer)
+check_cxx_compiler_flag(-fwrapv-pointer
+                        HAVE_CXX_FLAG_FWRAPV_POINTER)
+if(HAVE_CXX_FLAG_FWRAPV_POINTER)
+  add_compile_options(-fwrapv-pointer)
+endif()
 
-include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-fdelayed-template-parsing
                         HAVE_CXX_FLAG_FDELAYED_TEMPLATE_PARSING)
 if(HAVE_CXX_FLAG_FDELAYED_TEMPLATE_PARSING)


### PR DESCRIPTION
-fwrapv-pointer is a relatively recent flag and older versions of clang may not support it.

Hopefully older versions of clang also don't perform the UB optimisation that warrants the use of the flag in the first place
