### PR TITLE
[SPEC2017] Use llvm_test_library for the wrf_netcdf target of 521.wrf_r so that to add dependencies required for compiletime measurements

### DIFF
--- a/External/SPEC/CFP2017rate/521.wrf_r/CMakeLists.txt
+++ b/External/SPEC/CFP2017rate/521.wrf_r/CMakeLists.txt
@@ -73,6 +73,7 @@ if (NOT TARGET wrf_netcdf)
   ${SRC_DIR}/netcdf/posixio.c)
   add_library(wrf_netcdf OBJECT ${netcdf_sources})
   target_compile_definitions(wrf_netcdf PRIVATE SPEC_CASE_FLAG)
+  test_suite_add_build_dependencies(wrf_netcdf)
 endif ()
 
 ## test ########################################################################

--- a/External/SPEC/CFP2017rate/521.wrf_r/CMakeLists.txt
+++ b/External/SPEC/CFP2017rate/521.wrf_r/CMakeLists.txt
@@ -71,9 +71,8 @@ if (NOT TARGET wrf_netcdf)
   ${SRC_DIR}/netcdf/fort-var1io.c ${SRC_DIR}/netcdf/fort-vario.c
   ${SRC_DIR}/netcdf/fort-varmio.c ${SRC_DIR}/netcdf/varsio.c
   ${SRC_DIR}/netcdf/posixio.c)
-  add_library(wrf_netcdf OBJECT ${netcdf_sources})
+  llvm_test_library(wrf_netcdf OBJECT ${netcdf_sources})
   target_compile_definitions(wrf_netcdf PRIVATE SPEC_CASE_FLAG)
-  test_suite_add_build_dependencies(wrf_netcdf)
 endif ()
 
 ## test ########################################################################


### PR DESCRIPTION
Without this change, Fortran benchmarks of SPEC2017 fail to build. Steps to reproduce:

```
$ cmake -B builddir \
-DCMAKE_C_COMPILER=clang \
-DCMAKE_CXX_COMPILER=clang++ \
-DCMAKE_Fortran_COMPILER=flang \
-G Ninja \
-C cmake/caches/O3.cmake \
-DTEST_SUITE_SPEC2017_ROOT=path/to/cpu2017-v1.1.5 \ -DTEST_SUITE_RUN_TYPE=ref \
-DTEST_SUITE_FORTRAN=ON \
-DCMAKE_C_FLAGS=-Wno-implicit-int \
-DCMAKE_CXX_FLAGS=-Wno-implicit-int

$ cmake --build builddir/ -j1
[0/2] Re-checking globbed directories...
[1951/35275] Building C object External/SPEC/CFP2017rate/521.wrf_r/CMakeFiles/wrf_netcdf.dir/__/__/cpu2017-v1.1.5/benchspec/CPU/521.wrf_r/src/netcdf/attr.c.o FAILED:
...
/bin/sh: 1: builddir/tools/timeit: not found
```