### PR TITLE
[Fortran] Disable gfortran volatile8 test

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1053,6 +1053,8 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   binding_label_tests_26b.f90
   test_common_binding_labels_2_main.f03
   string_1.f90 # Expect error on 32 bits platform
+  volatile8.f90 # Expects error on bad dummy argument declarations
+                # llvm-project#137369
 
   # Tests that exercise gfortran's ability to set -std=f95 and then see errors on newer features
   abstract_type_1.f90

--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1053,7 +1053,10 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   binding_label_tests_26b.f90
   test_common_binding_labels_2_main.f03
   string_1.f90 # Expect error on 32 bits platform
-  volatile8.f90 # Expects error on bad dummy argument declarations
+  volatile8.f90 # Gfortran expects compilation errors for invalid uses of volatile; flang
+                # supports one of these as an extension, and the others ought to either be warnings
+                # or errors. See the flang extensions document: "A non-definable actual argument,
+                # including the case of a vector subscript, may be associated with an ASYNCHRONOUS or VOLATILE dummy argument"
                 # llvm-project#137369
 
   # Tests that exercise gfortran's ability to set -std=f95 and then see errors on newer features


### PR DESCRIPTION
This test expects the compiler to give a compilation error. Current LLVM flang does emit an error, but it's a TODO message because volatile variables are not handled yet. There are upcoming PRs to enable this though, and the front end ought to emit some diagnostic about this. Eugene E and Peter K are discussing whether these should be warnings or errors. While this is being discussed, disable the test so work on volatile can proceed.

[LLVM PR requiring this change](https://github.com/llvm/llvm-project/pull/132486)
[LLVM issue discussing how to handle this test case](https://github.com/llvm/llvm-project/issues/137369#issuecomment-2831344238)

CC @kiranchandramohan @eugeneepshteyn @vzakhari