### PR TITLE
[SPEC2017] Fix known macOS portablitiy issue in GCC

### DIFF
--- a/External/SPEC/CINT2017rate/502.gcc_r/CMakeLists.txt
+++ b/External/SPEC/CINT2017rate/502.gcc_r/CMakeLists.txt
@@ -7,6 +7,9 @@ endif ()
 speccpu2017_benchmark(RATE)
 
 add_definitions(-DSPEC_502 -DIN_GCC -DHAVE_CONFIG_H)
+if(APPLE)
+  add_definitions(-DSPEC_GCC_VARIADIC_FUNCTIONS_MISMATCH_WORKAROUND)
+endif()
 speccpu2017_add_include_dirs(. include spec_qsort)
 add_compile_options(-fgnu89-inline -fno-strict-aliasing)
 

--- a/External/SPEC/CINT2017speed/602.gcc_s/CMakeLists.txt
+++ b/External/SPEC/CINT2017speed/602.gcc_s/CMakeLists.txt
@@ -6,6 +6,10 @@ endif ()
 
 speccpu2017_benchmark(SPEED ORIGIN 502.gcc_r)
 
+if(APPLE)
+  add_definitions(-DSPEC_GCC_VARIADIC_FUNCTIONS_MISMATCH_WORKAROUND)
+endif()
+
 ## ref #########################################################################
 
 speccpu2017_run_test(


### PR DESCRIPTION
Fixes an ABI-related crash in GCC when running SPEC CPU2017.

See benchmark updates in:
https://www.spec.org/cpu2017/Docs/changes.html