### PR TITLE
[Fortran/gfortran] Skip some directories when generating test configurations

### DIFF
--- a/Fortran/gfortran/utils/update-test-config.py
+++ b/Fortran/gfortran/utils/update-test-config.py
@@ -163,6 +163,20 @@ def get_lines(filepath: str) -> list[str]:
     finally:
         return lines
 
+# Check if a test configuration should be generated for the given directory
+#
+# Multi-file tests consist of a single "main" file and some number of dependent
+# sources. Some directories only contain "dependent" sources. A test
+# configuration should not be generated for such directories.
+def should_generate_config(d: str) -> bool:
+    # The directories containing only dependent sources. These should be
+    # relative to the root directory containing the gfortran tests.
+    skip: list[str] = ['regression/coarray/add_sources']
+    for s in skip:
+        if d.endswith(s):
+            return False
+    return True
+
 # Collect the subdirectories of the gfortran directory which may contain tests.
 def get_subdirs(gfortran: str) -> list[str]:
     regression = os.path.join(gfortran, 'regression')
@@ -174,7 +188,8 @@ def get_subdirs(gfortran: str) -> list[str]:
     subdirs.append(torture)
     for root, dirs, _ in os.walk(torture):
         subdirs.extend([os.path.join(root, d) for d in dirs])
-    return subdirs
+
+    return list(filter(should_generate_config, subdirs))
 
 # Strip any leading and trailing whitespace from the string as well as any
 # optional quotes around the string. Then split the string on whitespace and

--- a/Fortran/gfortran/utils/update-test-config.py
+++ b/Fortran/gfortran/utils/update-test-config.py
@@ -163,7 +163,8 @@ def get_lines(filepath: str) -> list[str]:
     finally:
         return lines
 
-# Check if a test configuration should be generated for the given directory
+# Check if a test configuration should be generated for the given directory.
+# The directory will be an absolute path.
 #
 # Multi-file tests consist of a single "main" file and some number of dependent
 # sources. Some directories only contain "dependent" sources. A test
@@ -171,7 +172,7 @@ def get_lines(filepath: str) -> list[str]:
 def should_generate_config(d: str) -> bool:
     # The directories containing only dependent sources. These should be
     # relative to the root directory containing the gfortran tests.
-    skip: list[str] = ['regression/coarray/add_sources']
+    skip: list[str] = [os.path.join('regression', 'coarray', 'add_sources')]
     for s in skip:
         if d.endswith(s):
             return False


### PR DESCRIPTION
Some directories in the gfortran test suite only contain "dependent" sources. These are sources used in multi-file tests where only the "main" source file contains DejaGNU directives that are used to determine the behavior of the test. A list of such "dependents-only" directories have been added to the update-test-config script so a test configuration is not generated for them.