### PR TITLE
[SPEC2017] Use correct input/output file paths for different benchmark types

### DIFF
--- a/External/SPEC/CFP2017rate/503.bwaves_r/CMakeLists.txt
+++ b/External/SPEC/CFP2017rate/503.bwaves_r/CMakeLists.txt
@@ -48,17 +48,19 @@ speccpu2017_run_test(
   RUN_TYPE ref
 )
 
-speccpu2017_run_test(
-  < "${RUN_ref_DIR_REL}/bwaves_3.in"
-  STDOUT bwaves_3.out
-  RUN_TYPE ref
-)
+if (BENCHMARK_SUITE_TYPE STREQUAL rate)
+  speccpu2017_run_test(
+    < "${RUN_ref_DIR_REL}/bwaves_3.in"
+    STDOUT bwaves_3.out
+    RUN_TYPE ref
+  )
 
-speccpu2017_run_test(
-  < "${RUN_ref_DIR}/bwaves_4.in"
-  STDOUT bwaves_4.out
-  RUN_TYPE ref
-)
+  speccpu2017_run_test(
+    < "${RUN_ref_DIR}/bwaves_4.in"
+    STDOUT bwaves_4.out
+    RUN_TYPE ref
+  )
+endif ()
 
 
 ################################################################################

--- a/External/SPEC/CFP2017rate/521.wrf_r/CMakeLists.txt
+++ b/External/SPEC/CFP2017rate/521.wrf_r/CMakeLists.txt
@@ -17,16 +17,12 @@ speccpu2017_benchmark(RATE)
 # that will be processed by specpp and is common to ${PROG} and ${VALIDATOR}
 # wrf_netcdf an object library for the netcdf sources
 
-# There is only one argument to the validator. Only the location
-# of the reference data changes. Tolerances and filenames are hard
-# coded.
-#
 # ${SPECDIFF_BIN} is used to check that all the test pass in
 # diffwrf_output_01.txt. We replace this with a call to `diff -b` so
 # that SPEC need not be installed. The `-b` is used to ignore
 # extraneous whitespace.
 macro(wrf_validator)
-  cmake_parse_arguments(_carg "" "RUN_TYPE" "" ${ARGN})
+  cmake_parse_arguments(_carg "" "RUN_TYPE;WRF_OUT_FILE" "" ${ARGN})
 
   set(VALIDATOR wrf_validate-target_${BENCHMARK_SUITE_TYPE})
   if (NOT TARGET ${VALIDATOR})
@@ -41,7 +37,7 @@ macro(wrf_validator)
   llvm_test_verify(WORKDIR ${RUN_${_carg_RUN_TYPE}_DIR_REL}
     "%S/${VALIDATOR}"
     "${RUN_${_carg_RUN_TYPE}_DIR_REL}/compare/wrf_reference_01"
-    wrfout_d01_2000-01-24_14_00_00 >
+    ${_carg_WRF_OUT_FILE} >
     "${RUN_${_carg_RUN_TYPE}_DIR_REL}/diffwrf_output_01.txt" &&
     diff -b "${RUN_${_carg_RUN_TYPE}_DIR_REL}/diffwrf_output_01.txt" "${RUN_${_carg_RUN_TYPE}_DIR_REL}/compare/diffwrf_output_01.txt"
     RUN_TYPE ${_carg_RUN_TYPE}
@@ -79,19 +75,24 @@ endif ()
 
 speccpu2017_run_test(RUN_TYPE test)
 
-wrf_validator(RUN_TYPE test)
+wrf_validator(RUN_TYPE test WRF_OUT_FILE wrfout_d01_2000-01-24_12_10_00)
 
 ## train #######################################################################
 
 speccpu2017_run_test(RUN_TYPE train)
 
-wrf_validator(RUN_TYPE train)
+wrf_validator(RUN_TYPE train WRF_OUT_FILE wrfout_d01_2000-01-24_14_00_00)
 
 ## ref #########################################################################
 
 speccpu2017_run_test(RUN_TYPE ref)
 
-wrf_validator(RUN_TYPE ref)
+if (BENCHMARK_SUITE_TYPE STREQUAL rate)
+  wrf_validator(RUN_TYPE ref WRF_OUT_FILE wrfout_d01_2000-01-24_20_00_00)
+endif ()
+if (BENCHMARK_SUITE_TYPE STREQUAL speed)
+  wrf_validator(RUN_TYPE ref WRF_OUT_FILE wrfout_d01_2000-01-24_15_00_00)
+endif ()
 
 ################################################################################
 

--- a/External/SPEC/CFP2017rate/554.roms_r/CMakeLists.txt
+++ b/External/SPEC/CFP2017rate/554.roms_r/CMakeLists.txt
@@ -37,13 +37,22 @@ speccpu2017_run_test(
 )
 
 ## ref #########################################################################
-
-speccpu2017_run_test(
-  < ocean_benchmark2.in.x
-  STDOUT ocean_benchmark2.log
-  STDERR ocean_benchmark2.err
-  RUN_TYPE ref
+if (BENCHMARK_SUITE_TYPE STREQUAL rate)
+  speccpu2017_run_test(
+    < ocean_benchmark2.in.x
+    STDOUT ocean_benchmark2.log
+    STDERR ocean_benchmark2.err
+    RUN_TYPE ref
 )
+endif ()
+if (BENCHMARK_SUITE_TYPE STREQUAL speed)
+  speccpu2017_run_test(
+    < ocean_benchmark3.in.x
+    STDOUT ocean_benchmark3.log
+    STDERR ocean_benchmark3.err
+    RUN_TYPE ref
+)
+endif ()
 
 ################################################################################
 


### PR DESCRIPTION
These programs did not take into account the relationship between the benchmark type(rate vs. speed, test vs. train) and the input/output filenames.
- 503.bwaves_r
- 521.wrf_r
- 554.roms_r
- 603.bwaves_s
- 621.wrf_s
- 654.roms_s