### PR TITLE
[Fortran/gfortran] Disable failing test

### DIFF
--- a/Fortran/gfortran/regression/gomp/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/gomp/DisabledFiles.cmake
@@ -407,6 +407,7 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   #
   canonical-loop-2.f90
   crayptr2.f90
+  linear-8.f90
   polymorphic-mapping-4.f90
   polymorphic-mapping-5.f90
   pr33439.f90


### PR DESCRIPTION
This test should fail to compile with an "invalid character in name" error - or the equivalent in flang. However, it used to fail because the LINEAR clause was not implemented in the OpenMP DO construct. The clause is now supported, but flang does not issue the expected compile-time error which causes the test to fail.