### PR TITLE
[LoongArch] Disable float16-smoke.c test

### DIFF
--- a/SingleSource/Regression/C/float16-smoke.c
+++ b/SingleSource/Regression/C/float16-smoke.c
@@ -1,11 +1,11 @@
 #include <stdio.h>
 
 
-// Clang on s390x now supports _Float16, however the system libraries
-// on current distributions do not yet contain the necessary conversion
-// routines to actually run binaries using _Float16.  Disable the test
-// on s390x for now.
-#if defined(__FLT16_DIG__) && !defined(__s390x__)
+// Clang on loongarch and s390x now support _Float16, however the system
+// libraries on current distributions do not yet contain the necessary
+// conversion routines to actually run binaries using _Float16. Disable
+// the test on loongarch and s390x for now.
+#if defined(__FLT16_DIG__) && !defined(__loongarch__) && !defined(__s390x__)
 
 typedef _Float16 fp16_t;
 __attribute__((noinline))


### PR DESCRIPTION
Clang on loongarch now supports _Float16, and therefore the test is now attempted. However the system libraries on current distributions do not yet contain the necessary conversion routines to actually run binaries using _Float16, and so the attempt fails.

Disable the test on loongarch for now.