### PR TITLE
compare.py: Drop "hash" column for average merging

### DIFF
--- a/utils/compare.py
+++ b/utils/compare.py
@@ -120,6 +120,13 @@ def readmulti(filenames):
     return d
 
 
+def merge_values(values, merge_function):
+    # Drop the "hash" column because it's irreducible for averages.
+    if merge_function is pd.DataFrame.mean and "hash" in values.columns:
+        values = values[[c for c in values.columns if c != "hash"]]
+    return values.groupby(level=1).apply(merge_function)
+
+
 def get_values(values):
     # Create data view without diff column.
     if "diff" in values.columns:
@@ -417,11 +424,11 @@ def main():
         lhs = files[0:split]
         rhs = files[split + 1 :]
 
-        # Filter minimum of lhs and rhs
+        # Combine the multiple left and right hand sides.
         lhs_d = readmulti(lhs)
-        lhs_merged = lhs_d.groupby(level=1).apply(config.merge_function)
+        lhs_merged = merge_values(lhs_d, config.merge_function)
         rhs_d = readmulti(rhs)
-        rhs_merged = rhs_d.groupby(level=1).apply(config.merge_function)
+        rhs_merged = merge_values(rhs_d, config.merge_function)
 
         # Combine to new dataframe
         data = pd.concat(


### PR DESCRIPTION
I thought about asserting that all hashes are the same or pick the one with the best metric, but it doesn't seem useful because this property is for internal usage.

This is the only non-numeric column and otherwise an exception is raised:
```Python
Traceback (most recent call last):
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/groupby/groupby.py", line 1824, in apply
    result = self._python_apply_general(f, self._selected_obj)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/groupby/groupby.py", line 1885, in _python_apply_general
    values, mutated = self._grouper.apply_groupwise(f, data, self.axis)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/groupby/ops.py", line 919, in apply_groupwise
    res = f(group)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/frame.py", line 11700, in mean
    result = super().mean(axis, skipna, numeric_only, **kwargs)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/generic.py", line 12439, in mean
    return self._stat_function(
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/generic.py", line 12396, in _stat_function
    return self._reduce(
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/frame.py", line 11569, in _reduce
    res = df._mgr.reduce(blk_func)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/internals/managers.py", line 1500, in reduce
    nbs = blk.reduce(func)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/internals/blocks.py", line 406, in reduce
    result = func(self.values)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/frame.py", line 11488, in blk_func
    return op(values, axis=axis, skipna=skipna, **kwds)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/nanops.py", line 147, in f
    result = alt(values, axis=axis, skipna=skipna, **kwds)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/nanops.py", line 404, in new_func
    result = func(values, axis=axis, skipna=skipna, mask=mask, **kwargs)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/nanops.py", line 720, in nanmean
    the_sum = _ensure_numeric(the_sum)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/nanops.py", line 1686, in _ensure_numeric
    raise TypeError(f"Could not convert {x} to numeric")
TypeError: Could not convert ['ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370'] to numeric

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/guyda/third-party/test-suite/utils/compare.py", line 520, in <module>
    main()
  File "/home/guyda/third-party/test-suite/utils/compare.py", line 422, in main
    lhs_merged = lhs_d.groupby(level=1).apply(config.merge_function)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/groupby/groupby.py", line 1846, in apply
    return self._python_apply_general(f, self._obj_with_exclusions)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/groupby/groupby.py", line 1885, in _python_apply_general
    values, mutated = self._grouper.apply_groupwise(f, data, self.axis)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/groupby/ops.py", line 919, in apply_groupwise
    res = f(group)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/frame.py", line 11700, in mean
    result = super().mean(axis, skipna, numeric_only, **kwargs)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/generic.py", line 12439, in mean
    return self._stat_function(
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/generic.py", line 12396, in _stat_function
    return self._reduce(
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/frame.py", line 11569, in _reduce
    res = df._mgr.reduce(blk_func)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/internals/managers.py", line 1500, in reduce
    nbs = blk.reduce(func)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/internals/blocks.py", line 406, in reduce
    result = func(self.values)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/frame.py", line 11488, in blk_func
    return op(values, axis=axis, skipna=skipna, **kwds)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/nanops.py", line 147, in f
    result = alt(values, axis=axis, skipna=skipna, **kwds)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/nanops.py", line 404, in new_func
    result = func(values, axis=axis, skipna=skipna, mask=mask, **kwargs)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/nanops.py", line 720, in nanmean
    the_sum = _ensure_numeric(the_sum)
  File "/home/guyda/.venv/lib/python3.9/site-packages/pandas/core/nanops.py", line 1686, in _ensure_numeric
    raise TypeError(f"Could not convert {x} to numeric")
TypeError: Could not convert ['ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370ead8a4d533ec1912ee3d86ace532e370'] to numeric
```