### PR TITLE
Partially fix test failures with libstdc++ 15 in debug mode

### DIFF
--- a/MultiSource/Benchmarks/DOE-ProxyApps-C++/PENNANT/Mesh.cc
+++ b/MultiSource/Benchmarks/DOE-ProxyApps-C++/PENNANT/Mesh.cc
@@ -273,19 +273,19 @@ void Mesh::initInvMap() {
     sort(pcpair.begin(), pcpair.end());
     for (int i = 0; i < numc; ++i) {
         int p = pcpair[i].first;
-        int pp = pcpair[i+1].first;         
-        int pm = 0;
-        // pm is only used when i != 0
-        if(i != 0)
-            pm = pcpair[i-1].first;
         int c = pcpair[i].second;
-        int cp = pcpair[i+1].second;
 
-        if (i == 0 || p != pm)  mappcfirst[p] = c;
-        if (i+1 == numc || p != pp)
-            mapccnext[c] = -1;
-        else
-            mapccnext[c] = cp;
+        if (i == 0) mappcfirst[p] = c;
+        else {
+            int pm = pcpair[i-1].first;
+            if (p != pm) mappcfirst[p] = c;
+        }
+        mapccnext[c] = -1;
+        if (i+1 != numc) {
+            int pp = pcpair[i+1].first;
+            int cp = pcpair[i+1].second;
+            if (p == pp) mapccnext[c] = cp;
+        }
     }
 
 }

--- a/MultiSource/Benchmarks/DOE-ProxyApps-C++/miniFE/MatrixInitOp.hpp
+++ b/MultiSource/Benchmarks/DOE-ProxyApps-C++/miniFE/MatrixInitOp.hpp
@@ -76,8 +76,6 @@ struct MatrixInitOp<miniFE::CSRMatrix<MINIFE_SCALAR,MINIFE_LOCAL_ORDINAL,MINIFE_
      mesh(&input_mesh),
      dest_rows(&matrix.rows[0]),
      dest_rowoffsets(&matrix.row_offsets[0]),
-     dest_cols(&matrix.packed_cols[0]),
-     dest_coefs(&matrix.packed_coefs[0]),
      n(matrix.rows.size())
   {
     if (matrix.packed_cols.capacity() != matrix.packed_coefs.capacity()) {
@@ -93,6 +91,9 @@ struct MatrixInitOp<miniFE::CSRMatrix<MINIFE_SCALAR,MINIFE_LOCAL_ORDINAL,MINIFE_
 
     matrix.packed_cols.resize(nnz);
     matrix.packed_coefs.resize(nnz);
+
+    dest_cols = matrix.packed_cols.data();
+    dest_coefs = matrix.packed_coefs.data();
     dest_rowoffsets[n] = nnz;
 #ifdef HAVE_MPI 
    MPI_Comm_rank(MPI_COMM_WORLD, &proc);

--- a/SingleSource/UnitTests/Vectorizer/common.h
+++ b/SingleSource/UnitTests/Vectorizer/common.h
@@ -66,10 +66,18 @@ static std::mt19937 rng;
 // Initialize arrays A with random numbers.
 template <typename Ty>
 static void init_data(const std::unique_ptr<Ty[]> &A, unsigned N) {
-  std::uniform_int_distribution<uint64_t> distrib(
-      std::numeric_limits<Ty>::min(), std::numeric_limits<Ty>::max());
-  for (unsigned i = 0; i < N; i++)
-    A[i] = distrib(rng);
+  if constexpr (std::is_floating_point_v<Ty>) {
+    std::uniform_real_distribution<Ty> distrib(
+        std::numeric_limits<Ty>::min(), std::numeric_limits<Ty>::max());
+    for (unsigned i = 0; i < N; i++)
+      A[i] = distrib(rng);
+  } else {
+    using DistTy = std::conditional_t<std::is_signed_v<Ty>, int64_t, uint64_t>;
+    std::uniform_int_distribution<DistTy> distrib(
+        std::numeric_limits<Ty>::min(), std::numeric_limits<Ty>::max());
+    for (unsigned i = 0; i < N; i++)
+      A[i] = distrib(rng);
+  }
 }
 
 template <typename Ty>

--- a/SingleSource/UnitTests/Vectorizer/common.h
+++ b/SingleSource/UnitTests/Vectorizer/common.h
@@ -72,8 +72,7 @@ static void init_data(const std::unique_ptr<Ty[]> &A, unsigned N) {
     for (unsigned i = 0; i < N; i++)
       A[i] = distrib(rng);
   } else {
-    using DistTy = std::conditional_t<std::is_signed_v<Ty>, int64_t, uint64_t>;
-    std::uniform_int_distribution<DistTy> distrib(
+    std::uniform_int_distribution<Ty> distrib(
         std::numeric_limits<Ty>::min(), std::numeric_limits<Ty>::max());
     for (unsigned i = 0; i < N; i++)
       A[i] = distrib(rng);

--- a/SingleSource/UnitTests/matrix-types-spec.cpp
+++ b/SingleSource/UnitTests/matrix-types-spec.cpp
@@ -211,7 +211,7 @@ int main(void) {
   testTranspose<double, 3, 10>();
   testTranspose<double, 4, 3>();
   testTranspose<float, 31, 17>();
-  testTranspose<unsigned, 8, 7>();
+  testTranspose<signed, 8, 7>();
 
   testMultiply<double, 3, 3, 3>();
   testMultiply<double, 10, 21, 23>();


### PR DESCRIPTION
When compiling on Fedora 42, there are now test failures in debug mode (c.f. llvm/llvm-project#144678).
This PR fixes the test-failures for all tests but CLAMR where I couldn't figure out what the problem actually is and the code in the upstream repo seems substantially different now.

Most fixes should be fine as is but in `SingleSource/UnitTests/matrix-types-specs.cpp` I changed the type of a matrix to use signed integers instead of unsigned but it seems that these are only transpose tests so it should be fine?

Ping for potential review @nikic @fhahn 