### PR TITLE
[utils] Migrate compare.py shebang to python3

### DIFF
--- a/utils/compare.py
+++ b/utils/compare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Tool to filter, organize, compare and display benchmarking results. Usefull
 for smaller datasets. It works great with a few dozen runs it is not designed to
 deal with hundreds.


### PR DESCRIPTION
Many modern environments link `python` to Python 2 and `python3` to Python 3, so on those the script would be ran with Python 2. However, the script uses `pandas` and `scipy` which have long dropped support for Python 2. In addition, the code is effectively Python 3. Thus, its better to upgrade and explictly run the script using `python3`.