### PR TITLE
[AArch64] Skip test aarch64-init-cpu-features if FMV runtime unavailable.

### DIFF
--- a/SingleSource/Benchmarks/Misc/Makefile
+++ b/SingleSource/Benchmarks/Misc/Makefile
@@ -13,24 +13,12 @@ endif
 endif
 
 ifeq ($(ARCH),AArch64)
-	ifeq ($(TARGET_OS),Darwin)
-		CHECK_FMV := $(shell echo "void __init_cpu_features_resolver(void);" > CheckHasAArch64FMV.h && \
-			$(CC) -c -x c CheckHasAArch64FMV.h -o CheckHasAArch64FMV.o 2>/dev/null && \
-			echo yes || echo no; \
-			rm -f CheckHasAArch64FMV.h CheckHasAArch64FMV.o)
-		ifeq ($(CHECK_FMV),yes)
-			CFLAGS += -DHAS_DARWIN_FMV
-		endif
-	endif
-	ifeq ($(TARGET_OS),Linux)
-		CHECK_FMV := $(shell echo "void __init_cpu_features(void);" > CheckHasAArch64FMV.h && \
-			$(CC) -c -x c CheckHasAArch64FMV.h -o CheckHasAArch64FMV.o 2>/dev/null && \
-			echo yes || echo no; \
-			rm -f CheckHasAArch64FMV.h CheckHasAArch64FMV.o)
-		ifeq ($(CHECK_FMV),yes)
-			CFLAGS += -DHAS_LINUX_FMV
-		endif
-	endif
+ifeq ($(TARGET_OS),Darwin)
+CFLAGS += -DHAS_DARWIN_FMV
+endif
+ifeq ($(TARGET_OS),Linux)
+CFLAGS += -DHAS_LINUX_FMV	
+endif
 endif
 
 ifeq ($(ARCH),Mips)

--- a/SingleSource/Benchmarks/Misc/Makefile
+++ b/SingleSource/Benchmarks/Misc/Makefile
@@ -14,10 +14,24 @@ endif
 
 ifeq ($(ARCH),AArch64)
 ifeq ($(TARGET_OS),Darwin)
-CFLAGS += -DHAS_DARWIN_FMV
+SYMBOL = __init_cpu_features_resolver
 endif
 ifeq ($(TARGET_OS),Linux)
-CFLAGS += -DHAS_LINUX_FMV	
+SYMBOL = __init_cpu_features
+endif
+# TARGET_LLVMGCC refers to the compiler specified with the --cc option,
+# and can be checked in the build-tools.log file in the test results directory.
+SYMBOL := $(shell echo "extern void $(SYMBOL)(void); void (*p)() = $(SYMBOL); int main() {}" | \
+       $(TARGET_LLVMGCC) --rtlib=compiler-rt -x c - -o /dev/null 2>/dev/null && \
+       echo $(SYMBOL) || echo undefined)
+ifeq ($(SYMBOL),__init_cpu_features_resolver)
+CFLAGS += --rtlib=compiler-rt -DHAS_DARWIN_FMV
+endif
+ifeq ($(SYMBOL),__init_cpu_features)
+CFLAGS += --rtlib=compiler-rt -DHAS_LINUX_FMV
+endif
+ifeq ($(SYMBOL),undefined)
+PROGRAMS_TO_SKIP := aarch64-init-cpu-features
 endif
 endif
 

--- a/SingleSource/Benchmarks/Misc/Makefile
+++ b/SingleSource/Benchmarks/Misc/Makefile
@@ -12,6 +12,15 @@ PROGRAMS_TO_SKIP := dt
 endif
 endif
 
+ifeq ($(ARCH),AArch64)
+ifeq ($(TARGET_OS),Darwin)
+CFLAGS += -DHAS_DARWIN_FMV
+endif
+ifeq ($(TARGET_OS),Linux)
+CFLAGS += -DHAS_LINUX_FMV	
+endif
+endif
+
 ifeq ($(ARCH),Mips)
 RUNTIMELIMIT := 2000
 endif

--- a/SingleSource/Benchmarks/Misc/Makefile
+++ b/SingleSource/Benchmarks/Misc/Makefile
@@ -13,12 +13,24 @@ endif
 endif
 
 ifeq ($(ARCH),AArch64)
-ifeq ($(TARGET_OS),Darwin)
-CFLAGS += -DHAS_DARWIN_FMV
-endif
-ifeq ($(TARGET_OS),Linux)
-CFLAGS += -DHAS_LINUX_FMV	
-endif
+	ifeq ($(TARGET_OS),Darwin)
+		CHECK_FMV := $(shell echo "void __init_cpu_features_resolver(void);" > CheckHasAArch64FMV.h && \
+			$(CC) -c -x c CheckHasAArch64FMV.h -o CheckHasAArch64FMV.o 2>/dev/null && \
+			echo yes || echo no; \
+			rm -f CheckHasAArch64FMV.h CheckHasAArch64FMV.o)
+		ifeq ($(CHECK_FMV),yes)
+			CFLAGS += -DHAS_DARWIN_FMV
+		endif
+	endif
+	ifeq ($(TARGET_OS),Linux)
+		CHECK_FMV := $(shell echo "void __init_cpu_features(void);" > CheckHasAArch64FMV.h && \
+			$(CC) -c -x c CheckHasAArch64FMV.h -o CheckHasAArch64FMV.o 2>/dev/null && \
+			echo yes || echo no; \
+			rm -f CheckHasAArch64FMV.h CheckHasAArch64FMV.o)
+		ifeq ($(CHECK_FMV),yes)
+			CFLAGS += -DHAS_LINUX_FMV
+		endif
+	endif
 endif
 
 ifeq ($(ARCH),Mips)

--- a/SingleSource/Benchmarks/Misc/aarch64-init-cpu-features.c
+++ b/SingleSource/Benchmarks/Misc/aarch64-init-cpu-features.c
@@ -1,3 +1,5 @@
+#if defined(HAS_DARWIN_FMV) || defined(HAS_LINUX_FMV)
+
 #include <stdio.h>
 
 extern struct {
@@ -12,7 +14,10 @@ extern struct {
 
 void RUNTIME_INIT(void);
 
+#endif /* defined(HAS_DARWIN_FMV) || defined(HAS_LINUX_FMV) */
+
 int main() {
+#if defined(HAS_DARWIN_FMV) || defined(HAS_LINUX_FMV)
     RUNTIME_INIT();
     const unsigned long long first = __aarch64_cpu_features.features;
 
@@ -32,4 +37,5 @@ int main() {
         __aarch64_cpu_features.features = 0;
         RUNTIME_INIT();
     }
+#endif /* defined(HAS_DARWIN_FMV) || defined(HAS_LINUX_FMV) */
 }

--- a/SingleSource/Benchmarks/Misc/aarch64-init-cpu-features.c
+++ b/SingleSource/Benchmarks/Misc/aarch64-init-cpu-features.c
@@ -1,5 +1,3 @@
-#if defined(HAS_DARWIN_FMV) || defined(HAS_LINUX_FMV)
-
 #include <stdio.h>
 
 extern struct {
@@ -14,10 +12,7 @@ extern struct {
 
 void RUNTIME_INIT(void);
 
-#endif /* defined(HAS_DARWIN_FMV) || defined(HAS_LINUX_FMV) */
-
 int main() {
-#if defined(HAS_DARWIN_FMV) || defined(HAS_LINUX_FMV)
     RUNTIME_INIT();
     const unsigned long long first = __aarch64_cpu_features.features;
 
@@ -37,5 +32,4 @@ int main() {
         __aarch64_cpu_features.features = 0;
         RUNTIME_INIT();
     }
-#endif /* defined(HAS_DARWIN_FMV) || defined(HAS_LINUX_FMV) */
 }


### PR DESCRIPTION
## ERROR CONTEXT
Before this patch, LNT test runs on AArch64 platforms (e.g., macOS arm64) could fail with missing symbol errors:
```
--- Tested: 140 tests --
FAIL: SingleSource/Benchmarks/Misc/aarch64-init-cpu-features.compile_time (1 of 140)
FAIL: SingleSource/Benchmarks/Misc/aarch64-init-cpu-features.execution_time (29 of 140)
Processing Times
```
```
Undefined symbols for architecture arm64:
  "_RUNTIME_INIT", referenced from:
      _main in aarch64-init-cpu-features.llvm.o
ld: symbol(s) not found for architecture arm64
```

## Patch Description
- Selects __init_cpu_features_resolver for Darwin, and __init_cpu_features for Linux.
- Attempts to compile a dummy program to detect availability of the symbol via TARGET_LLVMGCC.
- Adds corresponding macro (HAS_DARWIN_FMV or HAS_LINUX_FMV) if detection succeeds.
- Skips test if the symbol is undefined.

This change fixes build errors when running LNT tests on AArch64 using Make rather than CMake.
This patch reflects the changes from [llvm/llvm-test-suite@d24d5dcd](https://github.com/llvm/llvm-test-suite/commit/d24d5dcdcbb748c52747823a0d3df20864fad600).

Co-authored-by: Lee Young Joon <dog3hk.dev@gmail.com>
Co-authored-by: Alexandros Lamprineas <alexandros.lamprineas@arm.com>
Co-authored-by: Momchil Velikov <momchil.velikov@arm.com>
