### PR TITLE
[FMV][AArch64] Skip test aarch64-init-cpu-features if runtime unavailable

### DIFF
--- a/SingleSource/Benchmarks/Misc/Makefile
+++ b/SingleSource/Benchmarks/Misc/Makefile
@@ -23,4 +23,25 @@ RUNTIMELIMIT:=10800
 endif
 endif
 
+ifeq ($(ARCH),AArch64)
+ifeq ($(TARGET_OS),Darwin)
+SYMBOL = __init_cpu_features_resolver
+endif
+ifeq ($(TARGET_OS),Linux)
+SYMBOL = __init_cpu_features
+endif
+SYMBOL := $(shell echo "extern void $(SYMBOL)(void); void (*p)() = $(SYMBOL); int main() {}" | \
+       $(TARGET_LLVMGCC) --rtlib=compiler-rt -x c - -o /dev/null 2>/dev/null && \
+       echo $(SYMBOL) || echo undefined)
+ifeq ($(SYMBOL),__init_cpu_features_resolver)
+CFLAGS += --rtlib=compiler-rt -DHAS_DARWIN_FMV
+endif
+ifeq ($(SYMBOL),__init_cpu_features)
+CFLAGS += --rtlib=compiler-rt -DHAS_LINUX_FMV
+endif
+ifeq ($(SYMBOL),undefined)
+PROGRAMS_TO_SKIP := aarch64-init-cpu-features
+endif
+endif
+
 include $(LEVEL)/SingleSource/Makefile.singlesrc


### PR DESCRIPTION
When we use make to build the llvm-test-suite instead of cmake
the test aarch64-init-cpu-features should be skipped unless one
of __init_cpu_features_resolver or __init_cpu_features is found.

Co-authored-by: Momchil Velikov <momchil.velikov@arm.com>