### PR TITLE
[Fortran/goacc] Disable routine-3

### DIFF
--- a/Fortran/gfortran/regression/goacc/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/goacc/DisabledFiles.cmake
@@ -91,6 +91,7 @@ file(GLOB SKIPPED_FILES CONFIGURE_DEPENDS
   private-explicit-parallel-1.f95
   private-explicit-serial-1.f95
   private-predetermined-serial-1.f95
+  routine-3.f90
   serial-tree.f95
 
   # error: unsupported OpenACC operation: acc.reduction


### PR DESCRIPTION
The test routine-3 fails after:
https://github.com/llvm/llvm-project/pull/149614
As noted by:
https://github.com/llvm/llvm-project/pull/149614#issuecomment-3133903215

This is because the OpenACC spec requires for all do loop induction variables
to be privatized, but the private recipe does not yet have a materialization
implementation. Thus disable it in the same way other tests in same category fail.