### PR TITLE
[utils] Remove useless compare.py output

### DIFF
--- a/utils/compare.py
+++ b/utils/compare.py
@@ -320,7 +320,6 @@ def print_result(
         formatters=formatters,
     )
     print(out)
-    print(d.describe())
 
 
 def main():


### PR DESCRIPTION
The last part of the output by `print(d.describe())` aggregates numbers from different programs and doesn't statistically makes sense, making it pure noise.

Next, I plan to support quantile merging, and stddev for mean.