### PR TITLE
[SPEC2017] Add CMAKE_C_FLAGS `-Wno-implicit-int` for 527.cam4_r.

### DIFF
--- a/External/SPEC/CFP2017rate/527.cam4_r/CMakeLists.txt
+++ b/External/SPEC/CFP2017rate/527.cam4_r/CMakeLists.txt
@@ -69,6 +69,8 @@ speccpu2017_add_include_dirs(
 # the netcdf modules are in the build directory for the rate test
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/../../CFP2017rate/527.cam4_r")
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-implicit-int")
+
 set(CAM4_C_DEFS "-DNO_SHR_VMATH;-DCO2A;-DPERGRO")
 list(APPEND CAM4_C_DEFS "-DPLON=144;-DPLAT=96;-DPLEV=26;-DPCNST=3;-DPCOLS=4")
 list(APPEND CAM4_C_DEFS "-DPTRM=1;-DPTRN=1;-DPTRK=1")


### PR DESCRIPTION
Without this patch, a compilation error will occur.:
```
cpu2017/benchspec/CPU/527.cam4_r/src/mpi.c:23:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
   23 | FORT_NAME( mpi_init_fort , MPI_INIT_FORT)
      | ^
      | int
```