### PR TITLE
Fix SPEC CPU 2017 benchmarks with GCC 15

### DIFF
--- a/External/SPEC/CFP2017rate/526.blender_r/CMakeLists.txt
+++ b/External/SPEC/CFP2017rate/526.blender_r/CMakeLists.txt
@@ -1219,5 +1219,6 @@ speccpu2017_add_executable(
   specrand/specrand.c
   spec_backtrace.c
 )
+set_property(TARGET ${PROG} PROPERTY C_STANDARD 17)
 set_property(TARGET ${PROG} PROPERTY CXX_STANDARD 98)
 speccpu2017_prepare_rundir()

--- a/External/SPEC/CFP2017rate/544.nab_r/CMakeLists.txt
+++ b/External/SPEC/CFP2017rate/544.nab_r/CMakeLists.txt
@@ -66,4 +66,5 @@ speccpu2017_add_executable(
   regex-alpha/regexec.c
   regex-alpha/regfree.c
 )
+set_property(TARGET ${PROG} PROPERTY C_STANDARD 17)
 speccpu2017_prepare_rundir()

--- a/External/SPEC/CINT2017rate/502.gcc_r/CMakeLists.txt
+++ b/External/SPEC/CINT2017rate/502.gcc_r/CMakeLists.txt
@@ -462,4 +462,5 @@ speccpu2017_add_executable(
   spec_qsort/spec_qsort.c
 )
 
+set_property(TARGET ${PROG} PROPERTY C_STANDARD 17)
 speccpu2017_prepare_rundir()

--- a/External/SPEC/CINT2017rate/523.xalancbmk_r/CMakeLists.txt
+++ b/External/SPEC/CINT2017rate/523.xalancbmk_r/CMakeLists.txt
@@ -25,6 +25,13 @@ if(HAVE_CXX_FLAG_FDELAYED_TEMPLATE_PARSING)
   add_compile_options(-fdelayed-template-parsing)
 endif()
 
+# Equivalent workaround for GCC: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116064
+check_cxx_compiler_flag(-Wno-error=template-body
+                        HAVE_CXX_FLAG_WNO_ERROR_TEMPLATE_BODY)
+if(HAVE_CXX_FLAG_WNO_ERROR_TEMPLATE_BODY)
+  add_compile_options(-Wno-error=template-body)
+endif()
+
 add_definitions(
   -DAPP_NO_THREADS
   -DXALAN_INMEM_MSG_LOADER


### PR DESCRIPTION
4 of the SPEC CPU 2017 benchmarks fail to build with the latest GCC, see: https://cc-perf.igalia.com/db_default/v4/nts/31

526.blender_r, 544.nab_r and 502.gcc_r fail because GCC 15 changed the default C standard to gnu23, so this fixes it by telling CMake to use -std=gnu17, which matches Clang's default. I checked and even though CMake doesn't mention gnu17 specifically, it passes -std=gnu17. This is the C version of 7ebe5edc24

523.xalancbmk_r fails for a latent error in a template. We've already had to workaround it in Clang in 92b58b3bf4c6001bff4c7c7f8f98305e3ead56ff but GCC has it's own specific -Wno-error flag to ignore it, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116064
