### PR TITLE
[MicroBenchmarks] Add benchmark for control-flow-vectorization.

### DIFF
--- a/MicroBenchmarks/LoopVectorization/CMakeLists.txt
+++ b/MicroBenchmarks/LoopVectorization/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 llvm_test_run()
 
 llvm_test_executable(LoopVectorizationBenchmarks
+  ControlFlowVectorization.cpp
   ConditionalScalarAssignment.cpp
   main.cpp
   MathFunctions.cpp

--- a/MicroBenchmarks/LoopVectorization/ControlFlowVectorization.cpp
+++ b/MicroBenchmarks/LoopVectorization/ControlFlowVectorization.cpp
@@ -1,0 +1,188 @@
+#include <iostream>
+#include <memory>
+#include <random>
+
+#include "benchmark/benchmark.h"
+
+#define ITERATIONS 100000
+
+template <typename T> using CFVFunc = void (*)(T *, unsigned);
+
+// Define conditional increment loop with given stride.
+#define DEF_COND_INC_LOOP(name, stride)                                        \
+  template <typename T>                                                        \
+  __attribute__((noinline)) static void run_##name##_autovec(T *A,             \
+                                                             unsigned N) {     \
+    for (unsigned i = 0; i < N; i++) {                                         \
+      if (i % stride == 0) {                                                   \
+        A[i] = A[i] + 1;                                                       \
+      }                                                                        \
+    }                                                                          \
+  }                                                                            \
+  template <typename T>                                                        \
+  __attribute__((noinline)) static void run_##name##_novec(T *A, unsigned N) { \
+    _Pragma("clang loop vectorize(disable) interleave(disable)")               \
+    for (unsigned i = 0; i < N; i++) {                                         \
+      if (i % stride == 0) {                                                   \
+        A[i] = A[i] + 1;                                                       \
+      }                                                                        \
+    }                                                                          \
+  }
+
+// Define conditional increment by value loop.
+#define DEF_COND_INC_VALUE_LOOP(name, marker)                                  \
+  template <typename T>                                                        \
+  __attribute__((noinline)) static void run_##name##_autovec(T *A,             \
+                                                             unsigned N) {     \
+    for (unsigned i = 0; i < N; i++) {                                         \
+      if (A[i] == marker) {                                                    \
+        A[i] = A[i] + 1;                                                       \
+      }                                                                        \
+    }                                                                          \
+  }                                                                            \
+  template <typename T>                                                        \
+  __attribute__((noinline)) static void run_##name##_novec(T *A, unsigned N) { \
+    _Pragma("clang loop vectorize(disable) interleave(disable)")               \
+    for (unsigned i = 0; i < N; i++) {                                         \
+      if (A[i] == marker) {                                                    \
+        A[i] = A[i] + 1;                                                       \
+      }                                                                        \
+    }                                                                          \
+  }
+
+// Define unconditional increment loop.
+template <typename T>
+__attribute__((noinline)) static void run_uncond_inc_autovec(T *A, unsigned N) {
+  for (unsigned i = 0; i < N; i++) {
+    A[i] = A[i] + 1;
+  }
+}
+
+template <typename T>
+__attribute__((noinline)) static void run_uncond_inc_novec(T *A, unsigned N) {
+  _Pragma("clang loop vectorize(disable) interleave(disable)")
+  for (unsigned i = 0; i < N; i++) {
+    A[i] = A[i] + 1;
+  }
+}
+
+// Define loops with different strides.
+// stride=2: 50% active lanes
+// stride=4: 25% active lanes
+// stride=8: 12.5% active lanes
+// stride=16: 6.25% active lanes
+// stride=32: 3.125% active lanes
+// stride=64: 1.5625% active lanes
+// stride=128: 0.78% active lanes
+DEF_COND_INC_LOOP(cond_inc_stride_2, 2)
+DEF_COND_INC_LOOP(cond_inc_stride_4, 4)
+DEF_COND_INC_LOOP(cond_inc_stride_8, 8)
+DEF_COND_INC_LOOP(cond_inc_stride_16, 16)
+DEF_COND_INC_LOOP(cond_inc_stride_32, 32)
+DEF_COND_INC_LOOP(cond_inc_stride_64, 64)
+DEF_COND_INC_LOOP(cond_inc_stride_128, 128)
+
+// Conditional increment by value (sparse condition).
+DEF_COND_INC_VALUE_LOOP(cond_inc_by_value, 42)
+
+// Initialize array with random numbers.
+template <typename T> static void init_data(T *A) {
+  std::uniform_int_distribution<T> dist(0, 100);
+  std::mt19937 rng(12345);
+  for (unsigned i = 0; i < ITERATIONS; i++) {
+    A[i] = dist(rng);
+  }
+}
+
+// Benchmark vectorized version.
+template <typename T>
+static void __attribute__((always_inline))
+benchmark_cfv_autovec(benchmark::State &state, CFVFunc<T> VecFn,
+                      CFVFunc<T> NoVecFn) {
+  std::unique_ptr<T[]> A(new T[ITERATIONS]);
+  std::unique_ptr<T[]> A_vec(new T[ITERATIONS]);
+  std::unique_ptr<T[]> A_novec(new T[ITERATIONS]);
+  init_data(&A[0]);
+
+#ifdef BENCH_AND_VERIFY
+  // Verify the vectorized and scalar versions produce the same results.
+  {
+    std::copy(&A[0], &A[0] + ITERATIONS, &A_vec[0]);
+    std::copy(&A[0], &A[0] + ITERATIONS, &A_novec[0]);
+    VecFn(&A_vec[0], ITERATIONS);
+    NoVecFn(&A_novec[0], ITERATIONS);
+    for (unsigned i = 0; i < ITERATIONS; i++) {
+      if (A_vec[i] != A_novec[i]) {
+        std::cerr << "ERROR: vectorization result different at index " << i
+                  << "; " << A_vec[i] << " != " << A_novec[i] << "\n";
+        exit(1);
+      }
+    }
+  }
+#endif
+
+  for (auto _ : state) {
+    std::copy(&A[0], &A[0] + ITERATIONS, &A_vec[0]);
+    VecFn(&A_vec[0], ITERATIONS);
+    benchmark::DoNotOptimize(A_vec);
+    benchmark::ClobberMemory();
+  }
+}
+
+// Benchmark version with vectorization disabled.
+template <typename T>
+static void __attribute__((always_inline))
+benchmark_cfv_novec(benchmark::State &state, CFVFunc<T> NoVecFn) {
+  std::unique_ptr<T[]> A(new T[ITERATIONS]);
+  std::unique_ptr<T[]> A_work(new T[ITERATIONS]);
+  init_data(&A[0]);
+
+  for (auto _ : state) {
+    std::copy(&A[0], &A[0] + ITERATIONS, &A_work[0]);
+    NoVecFn(&A_work[0], ITERATIONS);
+    benchmark::DoNotOptimize(A_work);
+    benchmark::ClobberMemory();
+  }
+}
+
+#define BENCHMARK_CFV_CASE(name, ty)                                           \
+  void BENCHMARK_##name##_autovec_##ty##_(benchmark::State &state) {           \
+    benchmark_cfv_autovec<ty>(state, run_##name##_autovec, run_##name##_novec);\
+  }                                                                            \
+  BENCHMARK(BENCHMARK_##name##_autovec_##ty##_)->Unit(benchmark::kNanosecond); \
+                                                                               \
+  void BENCHMARK_##name##_novec_##ty##_(benchmark::State &state) {             \
+    benchmark_cfv_novec<ty>(state, run_##name##_novec);                        \
+  }                                                                            \
+  BENCHMARK(BENCHMARK_##name##_novec_##ty##_)->Unit(benchmark::kNanosecond);
+
+// Unconditional increment benchmark.
+#define BENCHMARK_UNCOND_CASE(ty)                                              \
+  void BENCHMARK_uncond_inc_autovec_##ty##_(benchmark::State &state) {         \
+    benchmark_cfv_autovec<ty>(state, run_uncond_inc_autovec,                   \
+                              run_uncond_inc_novec);                           \
+  }                                                                            \
+  BENCHMARK(BENCHMARK_uncond_inc_autovec_##ty##_)                              \
+      ->Unit(benchmark::kNanosecond);                                          \
+                                                                               \
+  void BENCHMARK_uncond_inc_novec_##ty##_(benchmark::State &state) {           \
+    benchmark_cfv_novec<ty>(state, run_uncond_inc_novec);                      \
+  }                                                                            \
+  BENCHMARK(BENCHMARK_uncond_inc_novec_##ty##_)->Unit(benchmark::kNanosecond);
+
+// Add benchmarks for all variants.
+#define ADD_CFV_BENCHMARKS(ty)                                                 \
+  BENCHMARK_UNCOND_CASE(ty)                                                    \
+  BENCHMARK_CFV_CASE(cond_inc_stride_2, ty)                                    \
+  BENCHMARK_CFV_CASE(cond_inc_stride_4, ty)                                    \
+  BENCHMARK_CFV_CASE(cond_inc_stride_8, ty)                                    \
+  BENCHMARK_CFV_CASE(cond_inc_stride_16, ty)                                   \
+  BENCHMARK_CFV_CASE(cond_inc_stride_32, ty)                                   \
+  BENCHMARK_CFV_CASE(cond_inc_stride_64, ty)                                   \
+  BENCHMARK_CFV_CASE(cond_inc_stride_128, ty)                                  \
+  BENCHMARK_CFV_CASE(cond_inc_by_value, ty)
+
+ADD_CFV_BENCHMARKS(int64_t)
+ADD_CFV_BENCHMARKS(int32_t)
+ADD_CFV_BENCHMARKS(int16_t)
+

--- a/MicroBenchmarks/LoopVectorization/ControlFlowVectorization.cpp
+++ b/MicroBenchmarks/LoopVectorization/ControlFlowVectorization.cpp
@@ -67,23 +67,15 @@ __attribute__((noinline)) static void run_uncond_inc_novec(T *A, unsigned N) {
 }
 
 // Define loops with different strides.
-// stride=2: 50% active lanes
-// stride=4: 25% active lanes
-// stride=8: 12.5% active lanes
-// stride=16: 6.25% active lanes
-// stride=32: 3.125% active lanes
-// stride=64: 1.5625% active lanes
-// stride=128: 0.78% active lanes
-DEF_COND_INC_LOOP(cond_inc_stride_2, 2)
-DEF_COND_INC_LOOP(cond_inc_stride_4, 4)
-DEF_COND_INC_LOOP(cond_inc_stride_8, 8)
+// Stride 16 usually big enough to accross single vector which can test if
+// control-flow-vectorization is profitable on these loops.
 DEF_COND_INC_LOOP(cond_inc_stride_16, 16)
 DEF_COND_INC_LOOP(cond_inc_stride_32, 32)
 DEF_COND_INC_LOOP(cond_inc_stride_64, 64)
 DEF_COND_INC_LOOP(cond_inc_stride_128, 128)
 
-// Conditional increment by value (sparse condition).
-DEF_COND_INC_VALUE_LOOP(cond_inc_by_value, 42)
+// Conditional increment by value.
+DEF_COND_INC_VALUE_LOOP(cond_inc_by_value, 40)
 
 // Initialize array with random numbers.
 template <typename T> static void init_data(T *A) {
@@ -173,9 +165,6 @@ benchmark_cfv_novec(benchmark::State &state, CFVFunc<T> NoVecFn) {
 // Add benchmarks for all variants.
 #define ADD_CFV_BENCHMARKS(ty)                                                 \
   BENCHMARK_UNCOND_CASE(ty)                                                    \
-  BENCHMARK_CFV_CASE(cond_inc_stride_2, ty)                                    \
-  BENCHMARK_CFV_CASE(cond_inc_stride_4, ty)                                    \
-  BENCHMARK_CFV_CASE(cond_inc_stride_8, ty)                                    \
   BENCHMARK_CFV_CASE(cond_inc_stride_16, ty)                                   \
   BENCHMARK_CFV_CASE(cond_inc_stride_32, ty)                                   \
   BENCHMARK_CFV_CASE(cond_inc_stride_64, ty)                                   \

--- a/MicroBenchmarks/LoopVectorization/ControlFlowVectorization.cpp
+++ b/MicroBenchmarks/LoopVectorization/ControlFlowVectorization.cpp
@@ -6,15 +6,15 @@
 
 #define ITERATIONS 100000
 
-template <typename T> using CFVFunc = void (*)(T *, unsigned);
+template <typename T> using ControlFlowLoopFunc = void (*)(T *, unsigned);
 
-// Define conditional increment loop with given stride.
-#define DEF_COND_INC_LOOP(name, stride)                                        \
+// Define conditional loop with given branch taken frequency.
+#define DEF_COND_LOOP(name, branch_every_N)                                    \
   template <typename T>                                                        \
   __attribute__((noinline)) static void run_##name##_autovec(T *A,             \
                                                              unsigned N) {     \
     for (unsigned i = 0; i < N; i++) {                                         \
-      if (i % stride == 0) {                                                   \
+      if (i % branch_every_N == 0) {                                           \
         A[i] = A[i] + 1;                                                       \
       }                                                                        \
     }                                                                          \
@@ -22,15 +22,15 @@ template <typename T> using CFVFunc = void (*)(T *, unsigned);
   template <typename T>                                                        \
   __attribute__((noinline)) static void run_##name##_novec(T *A, unsigned N) { \
     _Pragma("clang loop vectorize(disable) interleave(disable)")               \
-    for (unsigned i = 0; i < N; i++) {                                         \
-      if (i % stride == 0) {                                                   \
+    for (unsigned i =0; i < N; i++) {                                          \
+      if (i % branch_every_N == 0) {                                           \
         A[i] = A[i] + 1;                                                       \
       }                                                                        \
     }                                                                          \
   }
 
-// Define conditional increment by value loop.
-#define DEF_COND_INC_VALUE_LOOP(name, marker)                                  \
+// Define conditional loop with taken frequency by data equals to marker.
+#define DEF_COND_VALUE_LOOP(name, marker)                                      \
   template <typename T>                                                        \
   __attribute__((noinline)) static void run_##name##_autovec(T *A,             \
                                                              unsigned N) {     \
@@ -52,30 +52,30 @@ template <typename T> using CFVFunc = void (*)(T *, unsigned);
 
 // Define unconditional increment loop.
 template <typename T>
-__attribute__((noinline)) static void run_uncond_inc_autovec(T *A, unsigned N) {
+__attribute__((noinline)) static void run_uncond_autovec(T *A, unsigned N) {
   for (unsigned i = 0; i < N; i++) {
     A[i] = A[i] + 1;
   }
 }
 
 template <typename T>
-__attribute__((noinline)) static void run_uncond_inc_novec(T *A, unsigned N) {
+__attribute__((noinline)) static void run_uncond_novec(T *A, unsigned N) {
   _Pragma("clang loop vectorize(disable) interleave(disable)")
   for (unsigned i = 0; i < N; i++) {
     A[i] = A[i] + 1;
   }
 }
 
-// Define loops with different strides.
-// Stride 16 usually big enough to accross single vector which can test if
-// control-flow-vectorization is profitable on these loops.
-DEF_COND_INC_LOOP(cond_inc_stride_16, 16)
-DEF_COND_INC_LOOP(cond_inc_stride_32, 32)
-DEF_COND_INC_LOOP(cond_inc_stride_64, 64)
-DEF_COND_INC_LOOP(cond_inc_stride_128, 128)
+DEF_COND_LOOP(cond_every_1_iter, 1)
+DEF_COND_LOOP(cond_every_2_iter, 2)
+DEF_COND_LOOP(cond_every_4_iter, 4)
+DEF_COND_LOOP(cond_every_8_iter, 8)
+DEF_COND_LOOP(cond_every_16_iter, 16)
+DEF_COND_LOOP(cond_every_32_iter, 32)
+DEF_COND_LOOP(cond_every_64_iter, 64)
 
-// Conditional increment by value.
-DEF_COND_INC_VALUE_LOOP(cond_inc_by_value, 40)
+// Branch taken by value
+DEF_COND_VALUE_LOOP(cond_by_value, 100)
 
 // Initialize array with random numbers.
 template <typename T> static void init_data(T *A) {
@@ -89,8 +89,9 @@ template <typename T> static void init_data(T *A) {
 // Benchmark vectorized version.
 template <typename T>
 static void __attribute__((always_inline))
-benchmark_cfv_autovec(benchmark::State &state, CFVFunc<T> VecFn,
-                      CFVFunc<T> NoVecFn) {
+benchmark_control_flow_loop_autovec(benchmark::State &state,
+                                   ControlFlowLoopFunc<T> VecFn,
+                                   ControlFlowLoopFunc<T> NoVecFn) {
   std::unique_ptr<T[]> A(new T[ITERATIONS]);
   std::unique_ptr<T[]> A_vec(new T[ITERATIONS]);
   std::unique_ptr<T[]> A_novec(new T[ITERATIONS]);
@@ -124,7 +125,8 @@ benchmark_cfv_autovec(benchmark::State &state, CFVFunc<T> VecFn,
 // Benchmark version with vectorization disabled.
 template <typename T>
 static void __attribute__((always_inline))
-benchmark_cfv_novec(benchmark::State &state, CFVFunc<T> NoVecFn) {
+benchmark_control_flow_loop_novec(benchmark::State &state,
+                                 ControlFlowLoopFunc<T> NoVecFn) {
   std::unique_ptr<T[]> A(new T[ITERATIONS]);
   std::unique_ptr<T[]> A_work(new T[ITERATIONS]);
   init_data(&A[0]);
@@ -137,41 +139,43 @@ benchmark_cfv_novec(benchmark::State &state, CFVFunc<T> NoVecFn) {
   }
 }
 
-#define BENCHMARK_CFV_CASE(name, ty)                                           \
+#define BENCHMARK_CONTROL_FLOW_VEC_CASE(name, ty)                              \
   void BENCHMARK_##name##_autovec_##ty##_(benchmark::State &state) {           \
-    benchmark_cfv_autovec<ty>(state, run_##name##_autovec, run_##name##_novec);\
+    benchmark_control_flow_loop_autovec<ty>(state, run_##name##_autovec,        \
+                                           run_##name##_novec);                \
   }                                                                            \
   BENCHMARK(BENCHMARK_##name##_autovec_##ty##_)->Unit(benchmark::kNanosecond); \
                                                                                \
   void BENCHMARK_##name##_novec_##ty##_(benchmark::State &state) {             \
-    benchmark_cfv_novec<ty>(state, run_##name##_novec);                        \
+    benchmark_control_flow_loop_novec<ty>(state, run_##name##_novec);           \
   }                                                                            \
   BENCHMARK(BENCHMARK_##name##_novec_##ty##_)->Unit(benchmark::kNanosecond);
 
 // Unconditional increment benchmark.
 #define BENCHMARK_UNCOND_CASE(ty)                                              \
-  void BENCHMARK_uncond_inc_autovec_##ty##_(benchmark::State &state) {         \
-    benchmark_cfv_autovec<ty>(state, run_uncond_inc_autovec,                   \
-                              run_uncond_inc_novec);                           \
+  void BENCHMARK_uncond_autovec_##ty##_(benchmark::State &state) {             \
+    benchmark_control_flow_loop_autovec<ty>(state, run_uncond_autovec,          \
+                                           run_uncond_novec);                  \
   }                                                                            \
-  BENCHMARK(BENCHMARK_uncond_inc_autovec_##ty##_)                              \
-      ->Unit(benchmark::kNanosecond);                                          \
+  BENCHMARK(BENCHMARK_uncond_autovec_##ty##_)->Unit(benchmark::kNanosecond);   \
                                                                                \
-  void BENCHMARK_uncond_inc_novec_##ty##_(benchmark::State &state) {           \
-    benchmark_cfv_novec<ty>(state, run_uncond_inc_novec);                      \
+  void BENCHMARK_uncond_novec_##ty##_(benchmark::State &state) {               \
+    benchmark_control_flow_loop_novec<ty>(state, run_uncond_novec);             \
   }                                                                            \
-  BENCHMARK(BENCHMARK_uncond_inc_novec_##ty##_)->Unit(benchmark::kNanosecond);
+  BENCHMARK(BENCHMARK_uncond_novec_##ty##_)->Unit(benchmark::kNanosecond);
 
-// Add benchmarks for all variants.
-#define ADD_CFV_BENCHMARKS(ty)                                                 \
+// Add benchmarks for all branch frequency variants.
+#define ADD_CONTROL_FLOW_VEC_BENCHMARKS(ty)                                    \
   BENCHMARK_UNCOND_CASE(ty)                                                    \
-  BENCHMARK_CFV_CASE(cond_inc_stride_16, ty)                                   \
-  BENCHMARK_CFV_CASE(cond_inc_stride_32, ty)                                   \
-  BENCHMARK_CFV_CASE(cond_inc_stride_64, ty)                                   \
-  BENCHMARK_CFV_CASE(cond_inc_stride_128, ty)                                  \
-  BENCHMARK_CFV_CASE(cond_inc_by_value, ty)
+  BENCHMARK_CONTROL_FLOW_VEC_CASE(cond_every_1_iter, ty)                       \
+  BENCHMARK_CONTROL_FLOW_VEC_CASE(cond_every_2_iter, ty)                       \
+  BENCHMARK_CONTROL_FLOW_VEC_CASE(cond_every_4_iter, ty)                       \
+  BENCHMARK_CONTROL_FLOW_VEC_CASE(cond_every_8_iter, ty)                       \
+  BENCHMARK_CONTROL_FLOW_VEC_CASE(cond_every_16_iter, ty)                      \
+  BENCHMARK_CONTROL_FLOW_VEC_CASE(cond_every_32_iter, ty)                      \
+  BENCHMARK_CONTROL_FLOW_VEC_CASE(cond_every_64_iter, ty)                      \
+  BENCHMARK_CONTROL_FLOW_VEC_CASE(cond_by_value, ty)
 
-ADD_CFV_BENCHMARKS(int64_t)
-ADD_CFV_BENCHMARKS(int32_t)
-ADD_CFV_BENCHMARKS(int16_t)
-
+ADD_CONTROL_FLOW_VEC_BENCHMARKS(int64_t)
+ADD_CONTROL_FLOW_VEC_BENCHMARKS(int32_t)
+ADD_CONTROL_FLOW_VEC_BENCHMARKS(int16_t)

--- a/MicroBenchmarks/LoopVectorization/ControlFlowVectorization.cpp
+++ b/MicroBenchmarks/LoopVectorization/ControlFlowVectorization.cpp
@@ -6,25 +6,27 @@
 
 #define ITERATIONS 100000
 
-template <typename T> using ControlFlowLoopFunc = void (*)(T *, unsigned);
+template <typename T> using ControlFlowLoopFunc = void (*)(T *, T *, unsigned);
 
 // Define conditional loop with given branch taken frequency.
 #define DEF_COND_LOOP(name, branch_every_N)                                    \
   template <typename T>                                                        \
-  __attribute__((noinline)) static void run_##name##_autovec(T *A,             \
+  __attribute__((noinline)) static void run_##name##_autovec(T *A, T *Output,  \
                                                              unsigned N) {     \
     for (unsigned i = 0; i < N; i++) {                                         \
       if (i % branch_every_N == 0) {                                           \
-        A[i] = A[i] + 1;                                                       \
+        Output[i] = A[i] + 1;                                                  \
       }                                                                        \
     }                                                                          \
   }                                                                            \
   template <typename T>                                                        \
-  __attribute__((noinline)) static void run_##name##_novec(T *A, unsigned N) { \
-    _Pragma("clang loop vectorize(disable) interleave(disable)")               \
-    for (unsigned i =0; i < N; i++) {                                          \
+  __attribute__((noinline)) static void run_##name##_novec(T *A, T *Output,    \
+                                                           unsigned N) {       \
+    _Pragma(                                                                   \
+        "clang loop vectorize(disable) interleave(disable)")                   \
+    for (unsigned i = 0; i < N; i++) {                                         \
       if (i % branch_every_N == 0) {                                           \
-        A[i] = A[i] + 1;                                                       \
+        Output[i] = A[i] + 1;                                                  \
       }                                                                        \
     }                                                                          \
   }
@@ -32,37 +34,41 @@ template <typename T> using ControlFlowLoopFunc = void (*)(T *, unsigned);
 // Define conditional loop with taken frequency by data equals to marker.
 #define DEF_COND_VALUE_LOOP(name, marker)                                      \
   template <typename T>                                                        \
-  __attribute__((noinline)) static void run_##name##_autovec(T *A,             \
+  __attribute__((noinline)) static void run_##name##_autovec(T *A, T *Output,  \
                                                              unsigned N) {     \
     for (unsigned i = 0; i < N; i++) {                                         \
       if (A[i] == marker) {                                                    \
-        A[i] = A[i] + 1;                                                       \
+        Output[i] = A[i] + 1;                                                  \
       }                                                                        \
     }                                                                          \
   }                                                                            \
   template <typename T>                                                        \
-  __attribute__((noinline)) static void run_##name##_novec(T *A, unsigned N) { \
-    _Pragma("clang loop vectorize(disable) interleave(disable)")               \
+  __attribute__((noinline)) static void run_##name##_novec(T *A, T *Output,    \
+                                                           unsigned N) {       \
+    _Pragma(                                                                   \
+        "clang loop vectorize(disable) interleave(disable)")                   \
     for (unsigned i = 0; i < N; i++) {                                         \
       if (A[i] == marker) {                                                    \
-        A[i] = A[i] + 1;                                                       \
+        Output[i] = A[i] + 1;                                                  \
       }                                                                        \
     }                                                                          \
   }
 
 // Define unconditional increment loop.
 template <typename T>
-__attribute__((noinline)) static void run_uncond_autovec(T *A, unsigned N) {
+__attribute__((noinline)) static void run_uncond_autovec(T *A, T *Output,
+                                                         unsigned N) {
   for (unsigned i = 0; i < N; i++) {
-    A[i] = A[i] + 1;
+    Output[i] = A[i] + 1;
   }
 }
 
 template <typename T>
-__attribute__((noinline)) static void run_uncond_novec(T *A, unsigned N) {
+__attribute__((noinline)) static void run_uncond_novec(T *A, T *Output,
+                                                       unsigned N) {
   _Pragma("clang loop vectorize(disable) interleave(disable)")
   for (unsigned i = 0; i < N; i++) {
-    A[i] = A[i] + 1;
+    Output[i] = A[i] + 1;
   }
 }
 
@@ -93,21 +99,19 @@ benchmark_control_flow_loop_autovec(benchmark::State &state,
                                    ControlFlowLoopFunc<T> VecFn,
                                    ControlFlowLoopFunc<T> NoVecFn) {
   std::unique_ptr<T[]> A(new T[ITERATIONS]);
-  std::unique_ptr<T[]> A_vec(new T[ITERATIONS]);
-  std::unique_ptr<T[]> A_novec(new T[ITERATIONS]);
+  std::unique_ptr<T[]> Output_vec(new T[ITERATIONS]);
+  std::unique_ptr<T[]> Output_novec(new T[ITERATIONS]);
   init_data(&A[0]);
 
 #ifdef BENCH_AND_VERIFY
   // Verify the vectorized and scalar versions produce the same results.
   {
-    std::copy(&A[0], &A[0] + ITERATIONS, &A_vec[0]);
-    std::copy(&A[0], &A[0] + ITERATIONS, &A_novec[0]);
-    VecFn(&A_vec[0], ITERATIONS);
-    NoVecFn(&A_novec[0], ITERATIONS);
+    VecFn(&A[0], &Output_vec[0], ITERATIONS);
+    NoVecFn(&A[0], &Output_novec[0], ITERATIONS);
     for (unsigned i = 0; i < ITERATIONS; i++) {
-      if (A_vec[i] != A_novec[i]) {
+      if (Output_vec[i] != Output_novec[i]) {
         std::cerr << "ERROR: vectorization result different at index " << i
-                  << "; " << A_vec[i] << " != " << A_novec[i] << "\n";
+                  << "; " << Output_vec[i] << " != " << Output_novec[i] << "\n";
         exit(1);
       }
     }
@@ -115,9 +119,9 @@ benchmark_control_flow_loop_autovec(benchmark::State &state,
 #endif
 
   for (auto _ : state) {
-    std::copy(&A[0], &A[0] + ITERATIONS, &A_vec[0]);
-    VecFn(&A_vec[0], ITERATIONS);
-    benchmark::DoNotOptimize(A_vec);
+    VecFn(&A[0], &Output_vec[0], ITERATIONS);
+    benchmark::DoNotOptimize(A);
+    benchmark::DoNotOptimize(Output_vec);
     benchmark::ClobberMemory();
   }
 }
@@ -128,13 +132,13 @@ static void __attribute__((always_inline))
 benchmark_control_flow_loop_novec(benchmark::State &state,
                                  ControlFlowLoopFunc<T> NoVecFn) {
   std::unique_ptr<T[]> A(new T[ITERATIONS]);
-  std::unique_ptr<T[]> A_work(new T[ITERATIONS]);
+  std::unique_ptr<T[]> Output(new T[ITERATIONS]);
   init_data(&A[0]);
 
   for (auto _ : state) {
-    std::copy(&A[0], &A[0] + ITERATIONS, &A_work[0]);
-    NoVecFn(&A_work[0], ITERATIONS);
-    benchmark::DoNotOptimize(A_work);
+    NoVecFn(&A[0], &Output[0], ITERATIONS);
+    benchmark::DoNotOptimize(A);
+    benchmark::DoNotOptimize(Output);
     benchmark::ClobberMemory();
   }
 }

--- a/MicroBenchmarks/LoopVectorization/ControlFlowVectorization.cpp
+++ b/MicroBenchmarks/LoopVectorization/ControlFlowVectorization.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <iostream>
 #include <memory>
 #include <random>
@@ -6,12 +7,12 @@
 
 #define ITERATIONS 100000
 
-template <typename T> using ControlFlowLoopFunc = void (*)(T *, T *, unsigned);
+template <typename T> using ControlFlowLoopFunc = void (*)(T *, T *, bool*, unsigned);
 
 // Define conditional loop with given branch taken frequency.
 #define DEF_COND_LOOP(name, branch_every_N)                                    \
   template <typename T>                                                        \
-  __attribute__((noinline)) static void run_##name##_autovec(T *A, T *Output,  \
+  __attribute__((noinline)) static void run_##name##_autovec(T *A, T *Output, bool *M,  \
                                                              unsigned N) {     \
     for (unsigned i = 0; i < N; i++) {                                         \
       if (i % branch_every_N == 0) {                                           \
@@ -20,7 +21,7 @@ template <typename T> using ControlFlowLoopFunc = void (*)(T *, T *, unsigned);
     }                                                                          \
   }                                                                            \
   template <typename T>                                                        \
-  __attribute__((noinline)) static void run_##name##_novec(T *A, T *Output,    \
+  __attribute__((noinline)) static void run_##name##_novec(T *A, T *Output,bool *M,   \
                                                            unsigned N) {       \
     _Pragma(                                                                   \
         "clang loop vectorize(disable) interleave(disable)")                   \
@@ -34,7 +35,7 @@ template <typename T> using ControlFlowLoopFunc = void (*)(T *, T *, unsigned);
 // Define conditional loop with taken frequency by data equals to marker.
 #define DEF_COND_VALUE_LOOP(name, marker)                                      \
   template <typename T>                                                        \
-  __attribute__((noinline)) static void run_##name##_autovec(T *A, T *Output,  \
+  __attribute__((noinline)) static void run_##name##_autovec(T *A, T *Output, bool *M, \
                                                              unsigned N) {     \
     for (unsigned i = 0; i < N; i++) {                                         \
       if (A[i] == marker) {                                                    \
@@ -43,7 +44,7 @@ template <typename T> using ControlFlowLoopFunc = void (*)(T *, T *, unsigned);
     }                                                                          \
   }                                                                            \
   template <typename T>                                                        \
-  __attribute__((noinline)) static void run_##name##_novec(T *A, T *Output,    \
+  __attribute__((noinline)) static void run_##name##_novec(T *A, T *Output, bool *M,   \
                                                            unsigned N) {       \
     _Pragma(                                                                   \
         "clang loop vectorize(disable) interleave(disable)")                   \
@@ -56,7 +57,7 @@ template <typename T> using ControlFlowLoopFunc = void (*)(T *, T *, unsigned);
 
 // Define unconditional increment loop.
 template <typename T>
-__attribute__((noinline)) static void run_uncond_autovec(T *A, T *Output,
+__attribute__((noinline)) static void run_uncond_autovec(T *A, T *Output, bool *M,
                                                          unsigned N) {
   for (unsigned i = 0; i < N; i++) {
     Output[i] = A[i] + 1;
@@ -64,11 +65,30 @@ __attribute__((noinline)) static void run_uncond_autovec(T *A, T *Output,
 }
 
 template <typename T>
-__attribute__((noinline)) static void run_uncond_novec(T *A, T *Output,
+__attribute__((noinline)) static void run_uncond_novec(T *A, T *Output, bool *M,
                                                        unsigned N) {
   _Pragma("clang loop vectorize(disable) interleave(disable)")
   for (unsigned i = 0; i < N; i++) {
     Output[i] = A[i] + 1;
+  }
+}
+
+template <typename T>
+__attribute__((noinline)) static void run_external_mask_autovec(T *A, T *Output, bool *M,
+                                                         unsigned N) {
+  for (unsigned i = 0; i < N; i++) {
+    if (M[i])
+      Output[i] = A[i] + 1;
+  }
+}
+
+template <typename T>
+__attribute__((noinline)) static void run_external_mask_novec(T *A, T *Output, bool *M,
+                                                       unsigned N) {
+  _Pragma("clang loop vectorize(disable) interleave(disable)")
+  for (unsigned i = 0; i < N; i++) {
+    if (M[i])
+      Output[i] = A[i] + 1;
   }
 }
 
@@ -84,11 +104,21 @@ DEF_COND_LOOP(cond_every_64_iter, 64)
 DEF_COND_VALUE_LOOP(cond_by_value, 100)
 
 // Initialize array with random numbers.
-template <typename T> static void init_data(T *A) {
+template <typename T>
+static void init_data(const std::unique_ptr<T[]> &A, unsigned N) {
   std::uniform_int_distribution<T> dist(0, 100);
   std::mt19937 rng(12345);
-  for (unsigned i = 0; i < ITERATIONS; i++) {
+  for (unsigned i = 0; i < N; i++) {
     A[i] = dist(rng);
+  }
+}
+
+// Initialize mask.
+static void init_mask(const std::unique_ptr<bool[]> &Mask, unsigned N) {
+  std::uniform_int_distribution<int> dist(0, 1);
+  std::mt19937 rng(12345);
+  for (unsigned i = 0; i < N; i++) {
+    Mask[i] = dist(rng);
   }
 }
 
@@ -99,15 +129,19 @@ benchmark_control_flow_loop_autovec(benchmark::State &state,
                                    ControlFlowLoopFunc<T> VecFn,
                                    ControlFlowLoopFunc<T> NoVecFn) {
   std::unique_ptr<T[]> A(new T[ITERATIONS]);
+  std::unique_ptr<bool[]> Mask(new bool[ITERATIONS]);
   std::unique_ptr<T[]> Output_vec(new T[ITERATIONS]);
   std::unique_ptr<T[]> Output_novec(new T[ITERATIONS]);
-  init_data(&A[0]);
+  init_data(A, ITERATIONS);
+  init_mask(Mask, ITERATIONS);
+  std::fill_n(Output_vec.get(), ITERATIONS, static_cast<T>(0));
+  std::fill_n(Output_novec.get(), ITERATIONS, static_cast<T>(0));
 
 #ifdef BENCH_AND_VERIFY
   // Verify the vectorized and scalar versions produce the same results.
   {
-    VecFn(&A[0], &Output_vec[0], ITERATIONS);
-    NoVecFn(&A[0], &Output_novec[0], ITERATIONS);
+    VecFn(&A[0], &Output_vec[0], &Mask[0], ITERATIONS);
+    NoVecFn(&A[0], &Output_novec[0], &Mask[0], ITERATIONS);
     for (unsigned i = 0; i < ITERATIONS; i++) {
       if (Output_vec[i] != Output_novec[i]) {
         std::cerr << "ERROR: vectorization result different at index " << i
@@ -119,9 +153,10 @@ benchmark_control_flow_loop_autovec(benchmark::State &state,
 #endif
 
   for (auto _ : state) {
-    VecFn(&A[0], &Output_vec[0], ITERATIONS);
+    VecFn(&A[0], &Output_vec[0], &Mask[0], ITERATIONS);
     benchmark::DoNotOptimize(A);
     benchmark::DoNotOptimize(Output_vec);
+    benchmark::DoNotOptimize(Mask);
     benchmark::ClobberMemory();
   }
 }
@@ -132,45 +167,63 @@ static void __attribute__((always_inline))
 benchmark_control_flow_loop_novec(benchmark::State &state,
                                  ControlFlowLoopFunc<T> NoVecFn) {
   std::unique_ptr<T[]> A(new T[ITERATIONS]);
+  std::unique_ptr<bool[]> Mask(new bool[ITERATIONS]);
   std::unique_ptr<T[]> Output(new T[ITERATIONS]);
-  init_data(&A[0]);
+  init_data(A, ITERATIONS);
+  init_mask(Mask, ITERATIONS);
+  std::fill_n(Output.get(), ITERATIONS, static_cast<T>(0));
 
   for (auto _ : state) {
-    NoVecFn(&A[0], &Output[0], ITERATIONS);
+    NoVecFn(&A[0], &Output[0], &Mask[0], ITERATIONS);
     benchmark::DoNotOptimize(A);
     benchmark::DoNotOptimize(Output);
+    benchmark::DoNotOptimize(Mask);
     benchmark::ClobberMemory();
   }
 }
 
 #define BENCHMARK_CONTROL_FLOW_VEC_CASE(name, ty)                              \
   void BENCHMARK_##name##_autovec_##ty##_(benchmark::State &state) {           \
-    benchmark_control_flow_loop_autovec<ty>(state, run_##name##_autovec,        \
+    benchmark_control_flow_loop_autovec<ty>(state, run_##name##_autovec,       \
                                            run_##name##_novec);                \
   }                                                                            \
   BENCHMARK(BENCHMARK_##name##_autovec_##ty##_)->Unit(benchmark::kNanosecond); \
                                                                                \
   void BENCHMARK_##name##_novec_##ty##_(benchmark::State &state) {             \
-    benchmark_control_flow_loop_novec<ty>(state, run_##name##_novec);           \
+    benchmark_control_flow_loop_novec<ty>(state, run_##name##_novec);          \
   }                                                                            \
   BENCHMARK(BENCHMARK_##name##_novec_##ty##_)->Unit(benchmark::kNanosecond);
+
+// Condition from external mask array.
+#define BENCHMARK_EXTERNAL_MASK_CASE(ty)                                              \
+  void BENCHMARK_external_mask_autovec_##ty##_(benchmark::State &state) {             \
+    benchmark_control_flow_loop_autovec<ty>(state, run_external_mask_autovec,         \
+                                           run_external_mask_novec);                  \
+  }                                                                            \
+  BENCHMARK(BENCHMARK_external_mask_autovec_##ty##_)->Unit(benchmark::kNanosecond);   \
+                                                                               \
+  void BENCHMARK_external_mask_novec_##ty##_(benchmark::State &state) {               \
+    benchmark_control_flow_loop_novec<ty>(state, run_external_mask_novec);            \
+  }                                                                            \
+  BENCHMARK(BENCHMARK_external_mask_novec_##ty##_)->Unit(benchmark::kNanosecond);
 
 // Unconditional increment benchmark.
 #define BENCHMARK_UNCOND_CASE(ty)                                              \
   void BENCHMARK_uncond_autovec_##ty##_(benchmark::State &state) {             \
-    benchmark_control_flow_loop_autovec<ty>(state, run_uncond_autovec,          \
+    benchmark_control_flow_loop_autovec<ty>(state, run_uncond_autovec,         \
                                            run_uncond_novec);                  \
   }                                                                            \
   BENCHMARK(BENCHMARK_uncond_autovec_##ty##_)->Unit(benchmark::kNanosecond);   \
                                                                                \
   void BENCHMARK_uncond_novec_##ty##_(benchmark::State &state) {               \
-    benchmark_control_flow_loop_novec<ty>(state, run_uncond_novec);             \
+    benchmark_control_flow_loop_novec<ty>(state, run_uncond_novec);            \
   }                                                                            \
   BENCHMARK(BENCHMARK_uncond_novec_##ty##_)->Unit(benchmark::kNanosecond);
 
 // Add benchmarks for all branch frequency variants.
 #define ADD_CONTROL_FLOW_VEC_BENCHMARKS(ty)                                    \
   BENCHMARK_UNCOND_CASE(ty)                                                    \
+  BENCHMARK_EXTERNAL_MASK_CASE(ty)                                                    \
   BENCHMARK_CONTROL_FLOW_VEC_CASE(cond_every_1_iter, ty)                       \
   BENCHMARK_CONTROL_FLOW_VEC_CASE(cond_every_2_iter, ty)                       \
   BENCHMARK_CONTROL_FLOW_VEC_CASE(cond_every_4_iter, ty)                       \


### PR DESCRIPTION

Included benchmarks with conditional loops to trigger control-flow vectorization. 
These cases can be used for measuring the  performance impact of control-flow vectorization across targets.
