### PR TITLE
Add gitignore entry for macOS DS Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pyc
 /build*
 .cache
+.DS_Store


### PR DESCRIPTION
Just a simple addition of the .DS_Store entry to the gitignore.