### PR TITLE
[compare.py] Add confidence interval

### DIFF
--- a/utils/compare.py
+++ b/utils/compare.py
@@ -128,7 +128,7 @@ def merge_values(values, merge_function):
 
 
 def get_values(values, lhs_name=None, rhs_name=None):
-    exclude_cols = ["diff", "t-value", "p-value", "significant"]
+    exclude_cols = ["diff", "t-value", "p-value", "significant", "ci_lower", "ci_upper"]
     exclude_cols.extend([f'std_{lhs_name}', f'std_{rhs_name}'])
     exclude_cols.extend([f'cv_{lhs_name}', f'cv_{rhs_name}'])
     values = values[[c for c in values.columns if c not in exclude_cols]]
@@ -181,9 +181,9 @@ def compute_statistics(lhs_d, rhs_d, metrics, alpha, coeff_var, lhs_name, rhs_na
             if len(lhs_values) >= 2 and len(rhs_values) >= 2:
                 lhs_std = lhs_values.std(ddof=1)
                 rhs_std = rhs_values.std(ddof=1)
+                lhs_mean = lhs_values.mean()
+                rhs_mean = rhs_values.mean()
                 if coeff_var:
-                    lhs_mean = lhs_values.mean()
-                    rhs_mean = rhs_values.mean()
                     stats_dict[metric][program] = {
                         f'cv_{lhs_name}': lhs_std / lhs_mean if lhs_mean != 0 else float('nan'),
                         f'cv_{rhs_name}': rhs_std / rhs_mean if rhs_mean != 0 else float('nan'),
@@ -193,10 +193,21 @@ def compute_statistics(lhs_d, rhs_d, metrics, alpha, coeff_var, lhs_name, rhs_na
                         f'std_{lhs_name}': lhs_std,
                         f'std_{rhs_name}': rhs_std,
                     }
-                t_stat, p_val = stats.ttest_ind(lhs_values, rhs_values)
-                stats_dict[metric][program]['t-value'] = t_stat
-                stats_dict[metric][program]['p-value'] = p_val
-                stats_dict[metric][program]['significant'] = "Y" if p_val < alpha else "N"
+                result = stats.ttest_ind(lhs_values, rhs_values)
+                stats_dict[metric][program]['t-value'] = result.statistic
+                stats_dict[metric][program]['p-value'] = result.pvalue
+                stats_dict[metric][program]['significant'] = "Y" if result.pvalue < alpha else "N"
+
+                ci_abs = result.confidence_interval(1 - alpha)
+                if lhs_mean != 0:
+                    # CI is for mean(lhs)-mean(rhs); negate for rhs-lhs
+                    ci_lo = -ci_abs.high / lhs_mean
+                    ci_hi = -ci_abs.low / lhs_mean
+                else:
+                    ci_lo = float('nan')
+                    ci_hi = float('nan')
+                stats_dict[metric][program]['ci_lower'] = ci_lo
+                stats_dict[metric][program]['ci_upper'] = ci_hi
             else:
                 if coeff_var:
                     stats_dict[metric][program] = {
@@ -211,6 +222,8 @@ def compute_statistics(lhs_d, rhs_d, metrics, alpha, coeff_var, lhs_name, rhs_na
                 stats_dict[metric][program]['t-value'] = float('nan')
                 stats_dict[metric][program]['p-value'] = float('nan')
                 stats_dict[metric][program]['significant'] = ""
+                stats_dict[metric][program]['ci_lower'] = float('nan')
+                stats_dict[metric][program]['ci_upper'] = float('nan')
 
     stat_col_names = []
     if coeff_var:
@@ -218,6 +231,7 @@ def compute_statistics(lhs_d, rhs_d, metrics, alpha, coeff_var, lhs_name, rhs_na
     else:
         stat_col_names += [f'std_{lhs_name}', f'std_{rhs_name}']
     stat_col_names += ['t-value', 'p-value', 'significant']
+    stat_col_names += ['ci_lower', 'ci_upper']
 
     return stats_dict, stat_col_names
 
@@ -397,6 +411,10 @@ def print_result(
             formatters[(m, f'cv_{lhs_name}')] = lambda x: "%4.1f%%" % (x * 100) if not pd.isna(x) else ""
         if (m, f'cv_{rhs_name}') in dataout.columns:
             formatters[(m, f'cv_{rhs_name}')] = lambda x: "%4.1f%%" % (x * 100) if not pd.isna(x) else ""
+        if (m, "ci_lower") in dataout.columns:
+            formatters[(m, "ci_lower")] = lambda x: "%4.1f%%" % (x * 100) if not pd.isna(x) else ""
+        if (m, "ci_upper") in dataout.columns:
+            formatters[(m, "ci_upper")] = lambda x: "%4.1f%%" % (x * 100) if not pd.isna(x) else ""
     # Turn index into a column so we can format it...
     formatted_program = dataout.index.to_series()
     if shorten_names:
@@ -448,6 +466,7 @@ def print_result(
     exclude_from_summary = ["t-value", "p-value", "significant"]
     exclude_from_summary.extend([f'std_{lhs_name}', f'std_{rhs_name}'])
     exclude_from_summary.extend([f'cv_{lhs_name}', f'cv_{rhs_name}'])
+    exclude_from_summary.extend(['ci_lower', 'ci_upper'])
     d_summary = d.drop(columns=exclude_from_summary, level=1, errors='ignore')
     print(d_summary.describe())
 
@@ -542,7 +561,7 @@ def main():
         action="store_true",
         dest="statistics",
         default=False,
-        help="Add statistical analysis columns (std, t-value, p-value, significance)",
+        help="Add statistical analysis columns (std, t-value, p-value, significance, confidence intervals)",
     )
     parser.add_argument(
         "--alpha",
@@ -608,7 +627,7 @@ def main():
                 alpha=config.alpha,
                 coeff_var=config.coefficient_variation,
                 lhs_name=config.lhs_name,
-                rhs_name=config.rhs_name
+                rhs_name=config.rhs_name,
             )
 
         # Merge data

--- a/utils/compare.py
+++ b/utils/compare.py
@@ -128,7 +128,7 @@ def merge_values(values, merge_function):
 
 
 def get_values(values, lhs_name=None, rhs_name=None):
-    exclude_cols = ["diff", "t-value", "p-value", "significant", "ci_lower", "ci_upper"]
+    exclude_cols = ["diff", "t-value", "p-value", "significant", "diff_ci"]
     exclude_cols.extend([f'std_{lhs_name}', f'std_{rhs_name}'])
     exclude_cols.extend([f'cv_{lhs_name}', f'cv_{rhs_name}'])
     values = values[[c for c in values.columns if c not in exclude_cols]]
@@ -163,7 +163,7 @@ def add_diff_column(metric, values, absolute_diff=False):
     return values
 
 
-def compute_statistics(lhs_d, rhs_d, metrics, alpha, coeff_var, lhs_name, rhs_name):
+def compute_statistics(lhs_d, rhs_d, metrics, alpha, coeff_var, lhs_name, rhs_name, confidence_interval=False):
     stats_dict = {}
 
     for metric in metrics:
@@ -198,16 +198,16 @@ def compute_statistics(lhs_d, rhs_d, metrics, alpha, coeff_var, lhs_name, rhs_na
                 stats_dict[metric][program]['p-value'] = result.pvalue
                 stats_dict[metric][program]['significant'] = "Y" if result.pvalue < alpha else "N"
 
-                ci_abs = result.confidence_interval(1 - alpha)
-                if lhs_mean != 0:
-                    # CI is for mean(lhs)-mean(rhs); negate for rhs-lhs
-                    ci_lo = -ci_abs.high / lhs_mean
-                    ci_hi = -ci_abs.low / lhs_mean
-                else:
-                    ci_lo = float('nan')
-                    ci_hi = float('nan')
-                stats_dict[metric][program]['ci_lower'] = ci_lo
-                stats_dict[metric][program]['ci_upper'] = ci_hi
+                if confidence_interval:
+                    ci_abs = result.confidence_interval(1 - alpha)
+                    if lhs_mean != 0:
+                        # CI is for mean(lhs)-mean(rhs); negate for rhs-lhs
+                        ci_lo = -ci_abs.high / lhs_mean
+                        ci_hi = -ci_abs.low / lhs_mean
+                    else:
+                        ci_lo = float('nan')
+                        ci_hi = float('nan')
+                    stats_dict[metric][program]['diff_ci'] = (ci_lo, ci_hi)
             else:
                 if coeff_var:
                     stats_dict[metric][program] = {
@@ -222,8 +222,6 @@ def compute_statistics(lhs_d, rhs_d, metrics, alpha, coeff_var, lhs_name, rhs_na
                 stats_dict[metric][program]['t-value'] = float('nan')
                 stats_dict[metric][program]['p-value'] = float('nan')
                 stats_dict[metric][program]['significant'] = ""
-                stats_dict[metric][program]['ci_lower'] = float('nan')
-                stats_dict[metric][program]['ci_upper'] = float('nan')
 
     stat_col_names = []
     if coeff_var:
@@ -231,7 +229,8 @@ def compute_statistics(lhs_d, rhs_d, metrics, alpha, coeff_var, lhs_name, rhs_na
     else:
         stat_col_names += [f'std_{lhs_name}', f'std_{rhs_name}']
     stat_col_names += ['t-value', 'p-value', 'significant']
-    stat_col_names += ['ci_lower', 'ci_upper']
+    if confidence_interval:
+        stat_col_names += ['diff_ci']
 
     return stats_dict, stat_col_names
 
@@ -411,10 +410,8 @@ def print_result(
             formatters[(m, f'cv_{lhs_name}')] = lambda x: "%4.1f%%" % (x * 100) if not pd.isna(x) else ""
         if (m, f'cv_{rhs_name}') in dataout.columns:
             formatters[(m, f'cv_{rhs_name}')] = lambda x: "%4.1f%%" % (x * 100) if not pd.isna(x) else ""
-        if (m, "ci_lower") in dataout.columns:
-            formatters[(m, "ci_lower")] = lambda x: "%4.1f%%" % (x * 100) if not pd.isna(x) else ""
-        if (m, "ci_upper") in dataout.columns:
-            formatters[(m, "ci_upper")] = lambda x: "%4.1f%%" % (x * 100) if not pd.isna(x) else ""
+        if (m, "diff_ci") in dataout.columns:
+            formatters[(m, "diff_ci")] = lambda x: "[%4.1f%%, %4.1f%%]" % (x[0] * 100, x[1] * 100) if isinstance(x, tuple) and not (pd.isna(x[0]) or pd.isna(x[1])) else ""
     # Turn index into a column so we can format it...
     formatted_program = dataout.index.to_series()
     if shorten_names:
@@ -466,7 +463,7 @@ def print_result(
     exclude_from_summary = ["t-value", "p-value", "significant"]
     exclude_from_summary.extend([f'std_{lhs_name}', f'std_{rhs_name}'])
     exclude_from_summary.extend([f'cv_{lhs_name}', f'cv_{rhs_name}'])
-    exclude_from_summary.extend(['ci_lower', 'ci_upper'])
+    exclude_from_summary.extend(['diff_ci'])
     d_summary = d.drop(columns=exclude_from_summary, level=1, errors='ignore')
     print(d_summary.describe())
 
@@ -561,7 +558,7 @@ def main():
         action="store_true",
         dest="statistics",
         default=False,
-        help="Add statistical analysis columns (std, t-value, p-value, significance, confidence intervals)",
+        help="Add statistical analysis columns (std, t-value, p-value, significance)",
     )
     parser.add_argument(
         "--alpha",
@@ -582,6 +579,13 @@ def main():
         dest="coefficient_variation",
         default=False,
         help="Compute relative coefficient of variation (%%) rather than absolute stddev",
+    )
+    parser.add_argument(
+        "--confidence-interval",
+        action="store_true",
+        dest="confidence_interval",
+        default=False,
+        help="Add confidence interval column (requires --statistics)",
     )
     config = parser.parse_args()
 
@@ -628,6 +632,7 @@ def main():
                 coeff_var=config.coefficient_variation,
                 lhs_name=config.lhs_name,
                 rhs_name=config.rhs_name,
+                confidence_interval=config.confidence_interval,
             )
 
         # Merge data

--- a/utils/compare.py
+++ b/utils/compare.py
@@ -411,7 +411,9 @@ def print_result(
         if (m, f'cv_{rhs_name}') in dataout.columns:
             formatters[(m, f'cv_{rhs_name}')] = lambda x: "%4.1f%%" % (x * 100) if not pd.isna(x) else ""
         if (m, "diff_ci") in dataout.columns:
-            formatters[(m, "diff_ci")] = lambda x: "[%4.1f%%, %4.1f%%]" % (x[0] * 100, x[1] * 100) if isinstance(x, tuple) and not (pd.isna(x[0]) or pd.isna(x[1])) else ""
+            formatters[(m, "diff_ci")] = lambda x: \
+                "[%4.1f%%, %4.1f%%]" % (x[0] * 100, x[1] * 100) \
+                if isinstance(x, tuple) and not (pd.isna(x[0]) or pd.isna(x[1])) else ""
     # Turn index into a column so we can format it...
     formatted_program = dataout.index.to_series()
     if shorten_names:

--- a/utils/compare.py
+++ b/utils/compare.py
@@ -128,9 +128,12 @@ def merge_values(values, merge_function):
 
 
 def get_values(values, lhs_name=None, rhs_name=None):
-    exclude_cols = ["diff", "t-value", "p-value", "significant", "diff_ci"]
-    exclude_cols.extend([f'std_{lhs_name}', f'std_{rhs_name}'])
-    exclude_cols.extend([f'cv_{lhs_name}', f'cv_{rhs_name}'])
+    exclude_cols = [
+        "diff", "t-value", "p-value", "significant",
+        f'std_{lhs_name}', f'std_{rhs_name}',
+        f'cv_{lhs_name}', f'cv_{rhs_name}',
+        "diff_ci_rel", "diff_ci_abs",
+    ]
     values = values[[c for c in values.columns if c not in exclude_cols]]
     has_two_runs = len(values.columns) == 2
     if has_two_runs:
@@ -163,7 +166,7 @@ def add_diff_column(metric, values, absolute_diff=False):
     return values
 
 
-def compute_statistics(lhs_d, rhs_d, metrics, alpha, coeff_var, lhs_name, rhs_name, confidence_interval=False):
+def compute_statistics(lhs_d, rhs_d, lhs_name, rhs_name, metrics, alpha, coeff_var, diff_conf_int):
     stats_dict = {}
 
     for metric in metrics:
@@ -193,21 +196,26 @@ def compute_statistics(lhs_d, rhs_d, metrics, alpha, coeff_var, lhs_name, rhs_na
                         f'std_{lhs_name}': lhs_std,
                         f'std_{rhs_name}': rhs_std,
                     }
-                result = stats.ttest_ind(lhs_values, rhs_values)
-                stats_dict[metric][program]['t-value'] = result.statistic
-                stats_dict[metric][program]['p-value'] = result.pvalue
-                stats_dict[metric][program]['significant'] = "Y" if result.pvalue < alpha else "N"
+                ttest = stats.ttest_ind(lhs_values, rhs_values)
+                stats_dict[metric][program]['t-value'] = ttest.statistic
+                stats_dict[metric][program]['p-value'] = ttest.pvalue
+                stats_dict[metric][program]['significant'] = "Y" if ttest.pvalue < alpha else "N"
 
-                if confidence_interval:
-                    ci_abs = result.confidence_interval(1 - alpha)
-                    if lhs_mean != 0:
-                        # CI is for mean(lhs)-mean(rhs); negate for rhs-lhs
-                        ci_lo = -ci_abs.high / lhs_mean
-                        ci_hi = -ci_abs.low / lhs_mean
+                if diff_conf_int:
+                    ci = ttest.confidence_interval(1 - alpha)
+                    # CI is for mean(lhs)-mean(rhs); negate for rhs-lhs
+                    abs_lo = -ci.high
+                    abs_hi = -ci.low
+                    if diff_conf_int == "relative":
+                        if lhs_mean != 0:
+                            ci_lo = abs_lo / lhs_mean
+                            ci_hi = abs_hi / lhs_mean
+                        else:
+                            ci_lo = float('nan')
+                            ci_hi = float('nan')
+                        stats_dict[metric][program]['diff_ci_rel'] = (ci_lo, ci_hi)
                     else:
-                        ci_lo = float('nan')
-                        ci_hi = float('nan')
-                    stats_dict[metric][program]['diff_ci'] = (ci_lo, ci_hi)
+                        stats_dict[metric][program]['diff_ci_abs'] = (abs_lo, abs_hi)
             else:
                 if coeff_var:
                     stats_dict[metric][program] = {
@@ -229,8 +237,10 @@ def compute_statistics(lhs_d, rhs_d, metrics, alpha, coeff_var, lhs_name, rhs_na
     else:
         stat_col_names += [f'std_{lhs_name}', f'std_{rhs_name}']
     stat_col_names += ['t-value', 'p-value', 'significant']
-    if confidence_interval:
-        stat_col_names += ['diff_ci']
+    if diff_conf_int == "relative":
+        stat_col_names += ['diff_ci_rel']
+    elif diff_conf_int == "absolute":
+        stat_col_names += ['diff_ci_abs']
 
     return stats_dict, stat_col_names
 
@@ -410,9 +420,13 @@ def print_result(
             formatters[(m, f'cv_{lhs_name}')] = lambda x: "%4.1f%%" % (x * 100) if not pd.isna(x) else ""
         if (m, f'cv_{rhs_name}') in dataout.columns:
             formatters[(m, f'cv_{rhs_name}')] = lambda x: "%4.1f%%" % (x * 100) if not pd.isna(x) else ""
-        if (m, "diff_ci") in dataout.columns:
-            formatters[(m, "diff_ci")] = lambda x: \
+        if (m, "diff_ci_rel") in dataout.columns:
+            formatters[(m, "diff_ci_rel")] = lambda x: \
                 "[%4.1f%%, %4.1f%%]" % (x[0] * 100, x[1] * 100) \
+                if isinstance(x, tuple) and not (pd.isna(x[0]) or pd.isna(x[1])) else ""
+        if (m, "diff_ci_abs") in dataout.columns:
+            formatters[(m, "diff_ci_abs")] = lambda x: \
+                "[%4.3f, %4.3f]" % (x[0], x[1]) \
                 if isinstance(x, tuple) and not (pd.isna(x[0]) or pd.isna(x[1])) else ""
     # Turn index into a column so we can format it...
     formatted_program = dataout.index.to_series()
@@ -462,10 +476,12 @@ def print_result(
         formatters=formatters,
     )
     print(out)
-    exclude_from_summary = ["t-value", "p-value", "significant"]
-    exclude_from_summary.extend([f'std_{lhs_name}', f'std_{rhs_name}'])
-    exclude_from_summary.extend([f'cv_{lhs_name}', f'cv_{rhs_name}'])
-    exclude_from_summary.extend(['diff_ci'])
+    exclude_from_summary = [
+        "t-value", "p-value", "significant",
+        f'std_{lhs_name}', f'std_{rhs_name}',
+        f'cv_{lhs_name}', f'cv_{rhs_name}',
+        'diff_ci_rel', 'diff_ci_abs',
+    ]
     d_summary = d.drop(columns=exclude_from_summary, level=1, errors='ignore')
     print(d_summary.describe())
 
@@ -583,11 +599,13 @@ def main():
         help="Compute relative coefficient of variation (%%) rather than absolute stddev",
     )
     parser.add_argument(
-        "--confidence-interval",
-        action="store_true",
-        dest="confidence_interval",
-        default=False,
-        help="Add confidence interval column (requires --statistics)",
+        "--diff-confidence-interval",
+        choices=["relative", "absolute"],
+        nargs="?",
+        const="relative",
+        default=None,
+        dest="diff_confidence_interval",
+        help="Show confidence interval for the difference (default: relative)",
     )
     config = parser.parse_args()
 
@@ -629,12 +647,13 @@ def main():
         if config.statistics:
             metrics_for_stats = config.metrics if len(config.metrics) > 0 else get_default_metric(lhs_d, rhs_d)
             stats_dict, stat_col_names = compute_statistics(
-                lhs_d, rhs_d, metrics_for_stats,
-                alpha=config.alpha,
-                coeff_var=config.coefficient_variation,
+                lhs_d, rhs_d,
                 lhs_name=config.lhs_name,
                 rhs_name=config.rhs_name,
-                confidence_interval=config.confidence_interval,
+                metrics=metrics_for_stats,
+                alpha=config.alpha,
+                coeff_var=config.coefficient_variation,
+                diff_conf_int=config.diff_confidence_interval,
             )
 
         # Merge data


### PR DESCRIPTION
This patch adds a `--diff-confidence-interval=relative|absolute` option to `compare.py` to report 95% (or 1-alpha) confidence intervals for the relative difference between `lhs` and `rhs` runs.

The current p-value and significance markers only tells the user if a difference is statistically significant against null hypothesis, but does not show how large the true difference might vary.

Example output from `compare.py ... --statistics --diff-confidence-interval`
```
     Program                                       exec_time
                                                   lhs       rhs    diff  std_lhs std_rhs t-value p-value significant diff_ci_rel
     C                                               2.95      3.40 15.3% 0.076   0.100   -6.653  0.0027  Y           [ 9.3%, 22.7%]
     A                                               1.00      1.15 15.0% 0.050   0.050   -3.674  0.0213  Y           [ 3.5%, 25.1%]
     B                                               1.95      2.20 12.8% 0.076   0.050   -4.427  0.0114  Y           [ 4.3%, 18.8%]
                                Geomean difference                  14.4%
```
