### PR TITLE
[cmake][Darwin] Add `TEST_SUITE_EXTERNALIZE_DEBUGINFO` for dSYM generation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,10 @@ option(TEST_SUITE_PROFILE_USE
       "Add apropriate -fprofile-instr-use to CFLAGS/CXXFLAGS for each benchmark"
       OFF)
 
+option(TEST_SUITE_EXTERNALIZE_DEBUGINFO
+      "Generate dSYM files for executables (Darwin only)"
+      OFF)
+
 # When running the test-suite in diagnosis mode, use these flags passed by
 # LNT to gather data, for examples -ftime-report, or -mllvm -stats. This way
 # the user specified CMAKE_C_FLAGS etc. need not be changed.

--- a/cmake/modules/TestSuite.cmake
+++ b/cmake/modules/TestSuite.cmake
@@ -64,16 +64,21 @@ function(llvm_test_executable_no_test target)
   test_suite_add_build_dependencies(${target})
 
   if(TEST_SUITE_EXTERNALIZE_DEBUGINFO AND APPLE)
+    string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
     if(CMAKE_C_FLAGS MATCHES "-flto"
       OR CMAKE_CXX_FLAGS MATCHES "-flto"
-      OR CMAKE_C_FLAGS_RELEASE MATCHES "-flto"
-      OR CMAKE_CXX_FLAGS_RELEASE MATCHES "-flto")
+      OR CMAKE_C_FLAGS_${uppercase_CMAKE_BUILD_TYPE} MATCHES "-flto"
+      OR CMAKE_CXX_FLAGS_${uppercase_CMAKE_BUILD_TYPE} MATCHES "-flto")
       set(lto_object ${CMAKE_CURRENT_BINARY_DIR}/${target}-lto.o)
       set_property(TARGET ${target} APPEND_STRING PROPERTY
         LINK_FLAGS " -Wl,-object_path_lto,${lto_object}")
     endif()
     if(NOT CMAKE_DSYMUTIL)
-      set(CMAKE_DSYMUTIL xcrun dsymutil)
+      execute_process(
+        COMMAND xcrun -f dsymutil
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        OUTPUT_VARIABLE CMAKE_DSYMUTIL
+      )
     endif()
     add_custom_command(TARGET ${target} POST_BUILD
       COMMAND ${CMAKE_DSYMUTIL} $<TARGET_FILE:${target}>)

--- a/cmake/modules/TestSuite.cmake
+++ b/cmake/modules/TestSuite.cmake
@@ -63,6 +63,22 @@ function(llvm_test_executable_no_test target)
   set_property(GLOBAL APPEND PROPERTY TEST_SUITE_TARGETS ${target})
   test_suite_add_build_dependencies(${target})
 
+  if(TEST_SUITE_EXTERNALIZE_DEBUGINFO AND APPLE)
+    if(CMAKE_C_FLAGS MATCHES "-flto"
+      OR CMAKE_CXX_FLAGS MATCHES "-flto"
+      OR CMAKE_C_FLAGS_RELEASE MATCHES "-flto"
+      OR CMAKE_CXX_FLAGS_RELEASE MATCHES "-flto")
+      set(lto_object ${CMAKE_CURRENT_BINARY_DIR}/${target}-lto.o)
+      set_property(TARGET ${target} APPEND_STRING PROPERTY
+        LINK_FLAGS " -Wl,-object_path_lto,${lto_object}")
+    endif()
+    if(NOT CMAKE_DSYMUTIL)
+      set(CMAKE_DSYMUTIL xcrun dsymutil)
+    endif()
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND ${CMAKE_DSYMUTIL} $<TARGET_FILE:${target}>)
+  endif()
+
   if(TEST_SUITE_LLVM_SIZE)
     add_custom_command(TARGET ${target} POST_BUILD
       COMMAND ${TEST_SUITE_LLVM_SIZE} --format=sysv $<SHELL_PATH:$<TARGET_FILE:${target}>>


### PR DESCRIPTION
Add a `TEST_SUITE_EXTERNALIZE_DEBUGINFO` CMake option that runs `dsymutil` as a post build step on Darwin to generate .dSYM bundles for each target on Darwin. When `-flto` flags are detected, this passes `-Wl,-object_path_lto` so `dsymutil` still has access to the original objects through OSO table.
