### PR TITLE
[Flang][OpenMP] Fix depend_iterator regression (omp_lib.mod not found)

### DIFF
--- a/Fortran/cray/OpenMP/5.0/depend_iterator_02.f90
+++ b/Fortran/cray/OpenMP/5.0/depend_iterator_02.f90
@@ -6,8 +6,8 @@
 ! OpenMP implementations, but it is expected to pass for CCE and flang.
 
 program main
-  use omp_lib
   implicit none
+  external :: omp_set_dynamic, omp_set_num_threads
   integer :: lll,uuu,sss,aaa(2)
 
   lll = 1

--- a/Fortran/cray/OpenMP/CMakeLists.txt
+++ b/Fortran/cray/OpenMP/CMakeLists.txt
@@ -1,1 +1,3 @@
-add_subdirectory(5.0)
+if(OPENMP_FOUND)
+  add_subdirectory(5.0)
+endif()


### PR DESCRIPTION
Fix regression due to https://github.com/llvm/llvm-test-suite/pull/375 by adding OpenMP check in cmake and replace `use omp_lib` with external declarations. (avoid .mod dependency file but probably not needed with the cmake guard)