### PR TITLE
[Fortran][test-suite] Update empty BIND(C) derived type expectations

### DIFF
--- a/Fortran/gfortran/regression/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/DisabledFiles.cmake
@@ -1011,7 +1011,6 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   allocate_error_8.f90
   do_concurrent_12.f90
   do_concurrent_15.f90
-  empty_derived_type_2.f90
   interface_51.f90
   interface_52.f90
   proc_ptr_56.f90

--- a/Fortran/gfortran/regression/override.yaml
+++ b/Fortran/gfortran/regression/override.yaml
@@ -139,3 +139,7 @@
 # on big endian target.
 "unsigned_21.f90":
   disabled_on: ["powerpc-*-aix"]
+
+# Flang now diagnoses empty BIND(C) derived types as errors.
+"empty_derived_type.f90":
+  xfail: true


### PR DESCRIPTION
This updates the Fortran test-suite fallout from llvm/llvm-project#193452.

Flang now correctly diagnoses empty `BIND(C)` derived types as errors, so `empty_derived_type.f90` is marked `xfail`, and `empty_derived_type_2.f90` is removed from `FAILING_FILES` now that it produces the expected error.