### PR TITLE
[Flang][Windows] Don't try to run Unix-specific tests on Windows

### DIFF
--- a/Fortran/cray/OpenMP/CMakeLists.txt
+++ b/Fortran/cray/OpenMP/CMakeLists.txt
@@ -1,3 +1,3 @@
-if(OPENMP_FOUND)
+if(OPENMP_FOUND AND NOT WIN32)
   add_subdirectory(5.0)
 endif()


### PR DESCRIPTION
Some of these recently added tests call functions only available in POSIX, and also assume that the linker accepts -fopenmp. These won't work on Windows, so we shouldn't attempt to build or run them there.