### PR TITLE
[FLANG] Add tests for AT edit descriptor (F2023).

### DIFF
--- a/Fortran/cray/f2023/13/07/CMakeLists.txt
+++ b/Fortran/cray/f2023/13/07/CMakeLists.txt
@@ -1,0 +1,3 @@
+llvm_singlesource()
+
+file(COPY lit.local.cfg DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")

--- a/Fortran/cray/f2023/13/07/at_edit01.f90
+++ b/Fortran/cray/f2023/13/07/at_edit01.f90
@@ -1,0 +1,115 @@
+! Self-checking execution tests for the AT edit descriptor
+! (Fortran 2023 Standard, 13.7.2).
+!
+! The AT edit descriptor outputs CHARACTER data with trailing blanks
+! removed (trimmed). It does not accept a width field.
+! AT may only be used for output, not input.
+!
+! Each test compares actual formatted output against an expected string
+! and prints PASS or FAIL. The reference output is just PASS lines.
+program at_edit01
+  implicit none
+  character(10) :: s10
+  character(20) :: s20
+  character(5)  :: s5
+  character(1)  :: s1
+  character(80) :: got
+  integer :: npass, nfail
+
+  npass = 0
+  nfail = 0
+
+  ! Test 1: Basic trailing blank trimming
+  s10 = "hello"
+  write(got, '("[",AT,"]")') s10
+  call check("basic trim", got, "[hello]")
+
+  ! Test 2: String fills variable exactly (no trailing blanks)
+  s5 = "world"
+  write(got, '("[",AT,"]")') s5
+  call check("exact fit", got, "[world]")
+
+  ! Test 3: All blanks become empty output
+  s10 = " "
+  write(got, '("[",AT,"]")') s10
+  call check("all blanks", got, "[]")
+
+  ! Test 4: Leading blanks are preserved
+  s10 = "  hello"
+  write(got, '("[",AT,"]")') s10
+  call check("leading blanks", got, "[  hello]")
+
+  ! Test 5: Internal blanks are preserved
+  s10 = "ab cd ef"
+  write(got, '("[",AT,"]")') s10
+  call check("internal blanks", got, "[ab cd ef]")
+
+  ! Test 6: Single non-blank character
+  s1 = "X"
+  write(got, '("[",AT,"]")') s1
+  call check("single char", got, "[X]")
+
+  ! Test 7: Single blank character
+  s1 = " "
+  write(got, '("[",AT,"]")') s1
+  call check("single blank", got, "[]")
+
+  ! Test 8: Repeat count (2AT)
+  s10 = "aaa"
+  s5 = "bb"
+  write(got, '("[",2AT,"]")') s10, s5
+  call check("2AT repeat", got, "[aaabb]")
+
+  ! Test 9: AT with 1X separator
+  s10 = "abc"
+  s5 = "de"
+  write(got, '("[",AT,1X,AT,"]")') s10, s5
+  call check("AT 1X AT", got, "[abc de]")
+
+  ! Test 10: Contrast AT vs A descriptor
+  s10 = "hi"
+  write(got, '("A :[",A,"]")') s10
+  call check("A descriptor", got, "A :[hi        ]")
+  write(got, '("AT:[",AT,"]")') s10
+  call check("AT descriptor", got, "AT:[hi]")
+
+  ! Test 11: Longer variable
+  s20 = "hello world"
+  write(got, '("[",AT,"]")') s20
+  call check("longer string", got, "[hello world]")
+
+  ! Test 12: Multiple items with different lengths
+  s20 = "first"
+  s10 = "second"
+  s5 = "third"
+  write(got, '("[",AT,"|",AT,"|",AT,"]")') s20, s10, s5
+  call check("multi items", got, "[first|second|third]")
+
+  ! Test 13: Preserves leading and internal blanks only
+  s20 = "  a  b  c"
+  write(got, '("[",AT,"]")') s20
+  call check("leading+internal blanks", got, "[  a  b  c]")
+
+  ! Test 14: Character literal (no trailing blanks to trim)
+  write(got, '("[",AT,"]")') "literal"
+  call check("char literal", got, "[literal]")
+
+  ! Summary
+  write(*,'(A,I0,A,I0,A)') "Result: ", npass, " passed, ", nfail, " failed"
+  if (nfail > 0) stop 1
+
+contains
+  subroutine check(name, actual, expected)
+    character(len=*), intent(in) :: name, actual, expected
+    if (trim(actual) == trim(expected)) then
+      write(*,'(A,A)') "PASS: ", name
+      npass = npass + 1
+    else
+      write(*,'(A,A)') "FAIL: ", name
+      write(*,'(A,A,A)') "  Expected: [", trim(expected), "]"
+      write(*,'(A,A,A)') "  Got:      [", trim(actual), "]"
+      nfail = nfail + 1
+    end if
+  end subroutine
+
+end program at_edit01

--- a/Fortran/cray/f2023/13/07/at_edit01.f90
+++ b/Fortran/cray/f2023/13/07/at_edit01.f90
@@ -1,5 +1,5 @@
 ! Self-checking execution tests for the AT edit descriptor
-! (Fortran 2023 Standard, 13.7.2).
+! (Fortran 2023 Standard, 13.7.4).
 !
 ! The AT edit descriptor outputs CHARACTER data with trailing blanks
 ! removed (trimmed). It does not accept a width field.

--- a/Fortran/cray/f2023/13/07/at_edit01.f90
+++ b/Fortran/cray/f2023/13/07/at_edit01.f90
@@ -21,78 +21,78 @@ program at_edit01
 
   ! Test 1: Basic trailing blank trimming
   s10 = "hello"
-  write(got, '("[",AT,"]")') s10
-  call check("basic trim", got, "[hello]")
+  write(got, '(AT)') s10
+  call check("basic trim", got, "hello")
 
   ! Test 2: String fills variable exactly (no trailing blanks)
   s5 = "world"
-  write(got, '("[",AT,"]")') s5
-  call check("exact fit", got, "[world]")
+  write(got, '(AT)') s5
+  call check("exact fit", got, "world")
 
   ! Test 3: All blanks become empty output
   s10 = " "
-  write(got, '("[",AT,"]")') s10
-  call check("all blanks", got, "[]")
+  write(got, '(AT)') s10
+  call check("all blanks", got, "")
 
   ! Test 4: Leading blanks are preserved
   s10 = "  hello"
-  write(got, '("[",AT,"]")') s10
-  call check("leading blanks", got, "[  hello]")
+  write(got, '(AT)') s10
+  call check("leading blanks", got, "  hello")
 
   ! Test 5: Internal blanks are preserved
   s10 = "ab cd ef"
-  write(got, '("[",AT,"]")') s10
-  call check("internal blanks", got, "[ab cd ef]")
+  write(got, '(AT)') s10
+  call check("internal blanks", got, "ab cd ef")
 
   ! Test 6: Single non-blank character
   s1 = "X"
-  write(got, '("[",AT,"]")') s1
-  call check("single char", got, "[X]")
+  write(got, '(AT)') s1
+  call check("single char", got, "X")
 
   ! Test 7: Single blank character
   s1 = " "
-  write(got, '("[",AT,"]")') s1
-  call check("single blank", got, "[]")
+  write(got, '(AT)') s1
+  call check("single blank", got, "")
 
   ! Test 8: Repeat count (2AT)
   s10 = "aaa"
   s5 = "bb"
-  write(got, '("[",2AT,"]")') s10, s5
-  call check("2AT repeat", got, "[aaabb]")
+  write(got, '(2AT)') s10, s5
+  call check("2AT repeat", got, "aaabb")
 
   ! Test 9: AT with 1X separator
   s10 = "abc"
   s5 = "de"
-  write(got, '("[",AT,1X,AT,"]")') s10, s5
-  call check("AT 1X AT", got, "[abc de]")
+  write(got, '(AT,1X,AT)') s10, s5
+  call check("AT 1X AT", got, "abc de")
 
   ! Test 10: Contrast AT vs A descriptor
   s10 = "hi"
-  write(got, '("A :[",A,"]")') s10
-  call check("A descriptor", got, "A :[hi        ]")
-  write(got, '("AT:[",AT,"]")') s10
-  call check("AT descriptor", got, "AT:[hi]")
+  write(got, '("A :",A)') s10
+  call check("A descriptor", got, "A :hi        ")
+  write(got, '("AT:",AT)') s10
+  call check("AT descriptor", got, "AT:hi")
 
   ! Test 11: Longer variable
   s20 = "hello world"
-  write(got, '("[",AT,"]")') s20
-  call check("longer string", got, "[hello world]")
+  write(got, '(AT)') s20
+  call check("longer string", got, "hello world")
 
   ! Test 12: Multiple items with different lengths
   s20 = "first"
   s10 = "second"
   s5 = "third"
-  write(got, '("[",AT,"|",AT,"|",AT,"]")') s20, s10, s5
-  call check("multi items", got, "[first|second|third]")
+  write(got, '(AT,"|",AT,"|",AT)') s20, s10, s5
+  call check("multi items", got, "first|second|third")
 
   ! Test 13: Preserves leading and internal blanks only
   s20 = "  a  b  c"
-  write(got, '("[",AT,"]")') s20
-  call check("leading+internal blanks", got, "[  a  b  c]")
+  write(got, '(AT)') s20
+  call check("leading+internal blanks", got, "  a  b  c")
 
   ! Test 14: Character literal (no trailing blanks to trim)
-  write(got, '("[",AT,"]")') "literal"
-  call check("char literal", got, "[literal]")
+  write(got, '(AT)') "literal"
+  call check("char literal", got, "literal")
 
   ! Summary
   write(*,'(A,I0,A,I0,A)') "Result: ", npass, " passed, ", nfail, " failed"

--- a/Fortran/cray/f2023/13/07/at_edit01.reference_output
+++ b/Fortran/cray/f2023/13/07/at_edit01.reference_output
@@ -1,0 +1,17 @@
+PASS: basic trim
+PASS: exact fit
+PASS: all blanks
+PASS: leading blanks
+PASS: internal blanks
+PASS: single char
+PASS: single blank
+PASS: 2AT repeat
+PASS: AT 1X AT
+PASS: A descriptor
+PASS: AT descriptor
+PASS: longer string
+PASS: multi items
+PASS: leading+internal blanks
+PASS: char literal
+Result: 15 passed, 0 failed
+exit 0

--- a/Fortran/cray/f2023/13/07/at_edit02.f90
+++ b/Fortran/cray/f2023/13/07/at_edit02.f90
@@ -1,6 +1,6 @@
 ! Self-checking execution tests for the AT edit descriptor with internal
 ! writes, FORMAT statements, and additional scenarios
-! (Fortran 2023 Standard, 13.7.2).
+! (Fortran 2023 Standard, 13.7.4).
 !
 ! Each test compares actual formatted output against an expected string
 ! and prints PASS or FAIL. The reference output is just PASS lines.
@@ -10,9 +10,12 @@ program at_edit02
   character(5)  :: s5
   character(50) :: buffer
   character(80) :: got
+  character(kind=2, len=80) :: got2
+  character(kind=4, len=80) :: got4
   character(:), allocatable :: alloc_str
   character(kind=2, len=10) :: s2
   character(kind=4, len=10) :: s4
+  character(80) :: line1, line2
   integer :: npass, nfail
 
   npass = 0
@@ -26,15 +29,15 @@ program at_edit02
 
   ! Test 2: AT with FORMAT statement
   s10 = "fmt"
-100 format("[",AT,"]")
+100 format(AT)
   write(got, 100) s10
-  call check("FORMAT stmt", got, "[fmt]")
+  call check("FORMAT stmt", got, "fmt")
 
   ! Test 3: 3AT repeat count with three items
   s10 = "xx"
   s5 = "yyy"
-  write(got, '("[",3AT,"]")') s10, s5, "z   "
-  call check("3AT repeat", got, "[xxyyyz]")
+  write(got, '(3AT)') s10, s5, "z   "
+  call check("3AT repeat", got, "xxyyyz")
 
   ! Test 4: AT with tab position descriptor
   s10 = "after tab"
@@ -43,32 +46,32 @@ program at_edit02
 
   ! Test 5: AT with character substring
   s10 = "abcdefghij"
-  write(got, '("[",AT,"]")') s10(1:5)
-  call check("substring", got, "[abcde]")
+  write(got, '(AT)') s10(1:5)
+  call check("substring", got, "abcde")
 
   ! Test 6: AT with allocatable character
   alloc_str = "allocated"
-  write(got, '("[",AT,"]")') alloc_str
-  call check("allocatable", got, "[allocated]")
+  write(got, '(AT)') alloc_str
+  call check("allocatable", got, "allocated")
   deallocate(alloc_str)
 
   ! Test 7: Internal write with all blanks
   s10 = "    "
-  write(buffer, '("[",AT,"]")') s10
-  call check("internal blanks", buffer, "[]")
+  write(buffer, '(AT)') s10
+  call check("internal blanks", buffer, "")
 
   ! Test 8: AT with various literal lengths
-  write(got, '("[",AT,"]")') "a"
-  call check("literal len 1", got, "[a]")
-  write(got, '("[",AT,"]")') "ab"
-  call check("literal len 2", got, "[ab]")
-  write(got, '("[",AT,"]")') "abc"
-  call check("literal len 3", got, "[abc]")
+  write(got, '(AT)') "a"
+  call check("literal len 1", got, "a")
+  write(got, '(AT)') "ab"
+  call check("literal len 2", got, "ab")
+  write(got, '(AT)') "abc"
+  call check("literal len 3", got, "abc")
 
   ! Test 9: AT with allocatable with trailing blanks
   alloc_str = "padded     "
-  write(got, '("[",AT,"]")') alloc_str
-  call check("alloc trailing blanks", got, "[padded]")
+  write(got, '(AT)') alloc_str
+  call check("alloc trailing blanks", got, "padded")
   deallocate(alloc_str)
 
   ! Test 10: AT in internal write then read back
@@ -78,28 +81,40 @@ program at_edit02
 
   ! Test 11: AT with kind=2 character
   s2 = 2_"hello"
-  write(got, '("[",AT,"]")') s2
-  call check("kind=2 trim", got, "[hello]")
+  write(got2, '(AT)') s2
+  call check2("kind=2 trim", got2, 2_"hello")
 
   ! Test 12: AT with kind=4 character
   s4 = 4_"hello"
-  write(got, '("[",AT,"]")') s4
-  call check("kind=4 trim", got, "[hello]")
+  write(got4, '(AT)') s4
+  call check4("kind=4 trim", got4, 4_"hello")
 
   ! Test 13: AT with kind=4 all blanks
   s4 = 4_" "
-  write(got, '("[",AT,"]")') s4
-  call check("kind=4 blanks", got, "[]")
+  write(got4, '(AT)') s4
+  call check4("kind=4 blanks", got4, 4_"")
 
   ! Test 14: AT with kind=2 leading blanks preserved
   s2 = 2_"  hi"
-  write(got, '("[",AT,"]")') s2
-  call check("kind=2 leading blanks", got, "[  hi]")
+  write(got2, '(AT)') s2
+  call check2("kind=2 leading blanks", got2, 2_"  hi")
 
   ! Test 15: AT with kind=4 internal blanks preserved
   s4 = 4_"a b c"
-  write(got, '("[",AT,"]")') s4
-  call check("kind=4 internal blanks", got, "[a b c]")
+  write(got4, '(AT)') s4
+  call check4("kind=4 internal blanks", got4, 4_"a b c")
+
+  ! Test 16: AT with embedded newline causes record advancement
+  ! The standard says a newline in the effective item ends the current
+  ! record and begins a new one (external file).
+  open(unit=10, status='scratch', action='readwrite')
+  write(10, '(AT)') "hello  " // char(10) // "world    "
+  rewind(10)
+  read(10, '(A)') line1
+  read(10, '(A)') line2
+  close(10)
+  call check("newline rec 1", line1, "hello")
+  call check("newline rec 2", line2, "world")
 
   ! Summary
   write(*,'(A,I0,A,I0,A)') "Result: ", npass, " passed, ", nfail, " failed"
@@ -108,6 +123,34 @@ program at_edit02
 contains
   subroutine check(name, actual, expected)
     character(len=*), intent(in) :: name, actual, expected
+    if (trim(actual) == trim(expected)) then
+      write(*,'(A,A)') "PASS: ", name
+      npass = npass + 1
+    else
+      write(*,'(A,A)') "FAIL: ", name
+      write(*,'(A,A,A)') "  Expected: [", trim(expected), "]"
+      write(*,'(A,A,A)') "  Got:      [", trim(actual), "]"
+      nfail = nfail + 1
+    end if
+  end subroutine
+
+  subroutine check2(name, actual, expected)
+    character(len=*), intent(in) :: name
+    character(kind=2, len=*), intent(in) :: actual, expected
+    if (trim(actual) == trim(expected)) then
+      write(*,'(A,A)') "PASS: ", name
+      npass = npass + 1
+    else
+      write(*,'(A,A)') "FAIL: ", name
+      write(*,'(A,A,A)') "  Expected: [", trim(expected), "]"
+      write(*,'(A,A,A)') "  Got:      [", trim(actual), "]"
+      nfail = nfail + 1
+    end if
+  end subroutine
+
+  subroutine check4(name, actual, expected)
+    character(len=*), intent(in) :: name
+    character(kind=4, len=*), intent(in) :: actual, expected
     if (trim(actual) == trim(expected)) then
       write(*,'(A,A)') "PASS: ", name
       npass = npass + 1

--- a/Fortran/cray/f2023/13/07/at_edit02.f90
+++ b/Fortran/cray/f2023/13/07/at_edit02.f90
@@ -1,0 +1,122 @@
+! Self-checking execution tests for the AT edit descriptor with internal
+! writes, FORMAT statements, and additional scenarios
+! (Fortran 2023 Standard, 13.7.2).
+!
+! Each test compares actual formatted output against an expected string
+! and prints PASS or FAIL. The reference output is just PASS lines.
+program at_edit02
+  implicit none
+  character(10) :: s10
+  character(5)  :: s5
+  character(50) :: buffer
+  character(80) :: got
+  character(:), allocatable :: alloc_str
+  character(kind=2, len=10) :: s2
+  character(kind=4, len=10) :: s4
+  integer :: npass, nfail
+
+  npass = 0
+  nfail = 0
+
+  ! Test 1: AT with internal write
+  s10 = "hello"
+  s5 = "world"
+  write(buffer, '(AT,1X,AT)') s10, s5
+  call check("internal write", buffer, "hello world")
+
+  ! Test 2: AT with FORMAT statement
+  s10 = "fmt"
+100 format("[",AT,"]")
+  write(got, 100) s10
+  call check("FORMAT stmt", got, "[fmt]")
+
+  ! Test 3: 3AT repeat count with three items
+  s10 = "xx"
+  s5 = "yyy"
+  write(got, '("[",3AT,"]")') s10, s5, "z   "
+  call check("3AT repeat", got, "[xxyyyz]")
+
+  ! Test 4: AT with tab position descriptor
+  s10 = "after tab"
+  write(got, '(T5,AT)') s10
+  call check("AT with T5", got, "    after tab")
+
+  ! Test 5: AT with character substring
+  s10 = "abcdefghij"
+  write(got, '("[",AT,"]")') s10(1:5)
+  call check("substring", got, "[abcde]")
+
+  ! Test 6: AT with allocatable character
+  alloc_str = "allocated"
+  write(got, '("[",AT,"]")') alloc_str
+  call check("allocatable", got, "[allocated]")
+  deallocate(alloc_str)
+
+  ! Test 7: Internal write with all blanks
+  s10 = "    "
+  write(buffer, '("[",AT,"]")') s10
+  call check("internal blanks", buffer, "[]")
+
+  ! Test 8: AT with various literal lengths
+  write(got, '("[",AT,"]")') "a"
+  call check("literal len 1", got, "[a]")
+  write(got, '("[",AT,"]")') "ab"
+  call check("literal len 2", got, "[ab]")
+  write(got, '("[",AT,"]")') "abc"
+  call check("literal len 3", got, "[abc]")
+
+  ! Test 9: AT with allocatable with trailing blanks
+  alloc_str = "padded     "
+  write(got, '("[",AT,"]")') alloc_str
+  call check("alloc trailing blanks", got, "[padded]")
+  deallocate(alloc_str)
+
+  ! Test 10: AT in internal write then read back
+  s10 = "round"
+  write(buffer, '(AT)') s10
+  call check("internal round-trip", buffer, "round")
+
+  ! Test 11: AT with kind=2 character
+  s2 = 2_"hello"
+  write(got, '("[",AT,"]")') s2
+  call check("kind=2 trim", got, "[hello]")
+
+  ! Test 12: AT with kind=4 character
+  s4 = 4_"hello"
+  write(got, '("[",AT,"]")') s4
+  call check("kind=4 trim", got, "[hello]")
+
+  ! Test 13: AT with kind=4 all blanks
+  s4 = 4_" "
+  write(got, '("[",AT,"]")') s4
+  call check("kind=4 blanks", got, "[]")
+
+  ! Test 14: AT with kind=2 leading blanks preserved
+  s2 = 2_"  hi"
+  write(got, '("[",AT,"]")') s2
+  call check("kind=2 leading blanks", got, "[  hi]")
+
+  ! Test 15: AT with kind=4 internal blanks preserved
+  s4 = 4_"a b c"
+  write(got, '("[",AT,"]")') s4
+  call check("kind=4 internal blanks", got, "[a b c]")
+
+  ! Summary
+  write(*,'(A,I0,A,I0,A)') "Result: ", npass, " passed, ", nfail, " failed"
+  if (nfail > 0) stop 1
+
+contains
+  subroutine check(name, actual, expected)
+    character(len=*), intent(in) :: name, actual, expected
+    if (trim(actual) == trim(expected)) then
+      write(*,'(A,A)') "PASS: ", name
+      npass = npass + 1
+    else
+      write(*,'(A,A)') "FAIL: ", name
+      write(*,'(A,A,A)') "  Expected: [", trim(expected), "]"
+      write(*,'(A,A,A)') "  Got:      [", trim(actual), "]"
+      nfail = nfail + 1
+    end if
+  end subroutine
+
+end program at_edit02

--- a/Fortran/cray/f2023/13/07/at_edit02.reference_output
+++ b/Fortran/cray/f2023/13/07/at_edit02.reference_output
@@ -15,5 +15,7 @@ PASS: kind=4 trim
 PASS: kind=4 blanks
 PASS: kind=2 leading blanks
 PASS: kind=4 internal blanks
-Result: 17 passed, 0 failed
+PASS: newline rec 1
+PASS: newline rec 2
+Result: 19 passed, 0 failed
 exit 0

--- a/Fortran/cray/f2023/13/07/at_edit02.reference_output
+++ b/Fortran/cray/f2023/13/07/at_edit02.reference_output
@@ -1,0 +1,19 @@
+PASS: internal write
+PASS: FORMAT stmt
+PASS: 3AT repeat
+PASS: AT with T5
+PASS: substring
+PASS: allocatable
+PASS: internal blanks
+PASS: literal len 1
+PASS: literal len 2
+PASS: literal len 3
+PASS: alloc trailing blanks
+PASS: internal round-trip
+PASS: kind=2 trim
+PASS: kind=4 trim
+PASS: kind=4 blanks
+PASS: kind=2 leading blanks
+PASS: kind=4 internal blanks
+Result: 17 passed, 0 failed
+exit 0

--- a/Fortran/cray/f2023/13/07/lit.local.cfg
+++ b/Fortran/cray/f2023/13/07/lit.local.cfg
@@ -1,0 +1,2 @@
+config.traditional_output = True
+config.single_source = True

--- a/Fortran/cray/f2023/13/CMakeLists.txt
+++ b/Fortran/cray/f2023/13/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(07)
 add_subdirectory(08)


### PR DESCRIPTION
These tests will test the execution of AT edit descriptor, issue [#181379](https://github.com/llvm/llvm-project/issues/181379) implemented by PR [#189157](https://github.com/llvm/llvm-project/pull/189157).