### PR TITLE
[Apple] Support benchmarking multiple Mach-O slices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,14 @@ if(TEST_SUITE_FORTRAN)
 endif()
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${TEST_SUITE_ARCH_FLAGS}")
 
+# Architectures to run tests as. Defaults to CMAKE_OSX_ARCHITECTURES so that
+# fat binaries are tested on every slice they were built for. Set to a single
+# arch to run only that slice (test names are unsuffixed); set to multiple
+# arches to run a separate test per slice (test names are suffixed with the
+# arch, e.g. foo.arm64.test, foo.arm64e.test).
+set(TEST_SUITE_RUN_ARCHS "${CMAKE_OSX_ARCHITECTURES}" CACHE STRING
+    "Semicolon-separated list of Mach-O arch slices to run tests as.")
+
 set(LLVM_CODESIGNING_IDENTITY "" CACHE STRING
   "Sign executables and dylibs with the given identity or skip if empty (Darwin Only)")
 

--- a/cmake/modules/TestFile.cmake
+++ b/cmake/modules/TestFile.cmake
@@ -114,6 +114,22 @@ function(llvm_add_test testfile executable)
 endfunction()
 
 function(llvm_add_test_for_target target)
-  llvm_add_test($<TARGET_FILE:${target}>.test %S/$<TARGET_FILE_NAME:${target}>)
+  list(LENGTH TEST_SUITE_RUN_ARCHS _num_run_archs)
+  if(_num_run_archs GREATER 1)
+    # Multiple run archs: emit one suffixed .test file per arch.
+    string(REPLACE "$EXECUTABLE$" "%S/$<TARGET_FILE_NAME:${target}>" _script "${TESTSCRIPT}")
+    foreach(_arch IN LISTS TEST_SUITE_RUN_ARCHS)
+      file(GENERATE
+        OUTPUT "$<TARGET_FILE:${target}>.${_arch}.test"
+        CONTENT "ARCH: ${_arch}\n${_script}")
+    endforeach()
+  else()
+    # Zero or one run arch: emit the normal unsuffixed .test file, preserving
+    # name stability in LNT.
+    if(_num_run_archs EQUAL 1)
+      set(TESTSCRIPT "ARCH: ${TEST_SUITE_RUN_ARCHS}\n${TESTSCRIPT}")
+    endif()
+    llvm_add_test($<TARGET_FILE:${target}>.test %S/$<TARGET_FILE_NAME:${target}>)
+  endif()
   set(TESTSCRIPT "" PARENT_SCOPE)
 endfunction()

--- a/litsupport/modules/timeit.py
+++ b/litsupport/modules/timeit.py
@@ -25,6 +25,9 @@ def _mutateCommandLine(context, commandline):
         args += ["--limit-file-size", "209715200"]
         args += ["--limit-rss-size", "838860800"]
 
+    if getattr(context, "arch", None):
+        args += ["-arch", context.arch]
+
     workdir = os.path.normpath(cmd.workdir) if cmd.workdir is not None else None
 
     if not config.traditional_output:

--- a/litsupport/modules/timeit.py
+++ b/litsupport/modules/timeit.py
@@ -3,6 +3,9 @@ from litsupport import testplan
 import os
 import re
 
+# Must match EXITCODE_EXEC_BADARCH in tools/timeit.c
+_EXITCODE_EXEC_BADARCH = 70
+
 
 def _mutateCommandLine(context, commandline):
     timefile = os.path.normpath(context.tmpBase + ".time")
@@ -94,6 +97,8 @@ def mutatePlan(context, plan):
     plan.metric_collectors.append(
         lambda context: _collectTime(context, context.timefiles)
     )
+    if getattr(context, "arch", None):
+        plan.unsupported_exit_codes.append(_EXITCODE_EXEC_BADARCH)
 
 
 def getUserTimeFromContents(contents):

--- a/litsupport/test.py
+++ b/litsupport/test.py
@@ -11,7 +11,6 @@ import litsupport.testfile
 import litsupport.testplan
 import os
 import pathlib
-import subprocess
 
 
 # The ResultCode constructor has been changed recently in lit.  An additional parameter has ben added, which
@@ -42,25 +41,6 @@ class TestSuiteTest(lit.formats.ShTest):
         pathlib.Path(tmpBase).parent.mkdir(parents=True, exist_ok=True)
         context = litsupport.testplan.TestContext(test, litConfig, tmpDir, tmpBase)
         litsupport.testfile.parse(context, test.getSourcePath())
-
-        # If the test targets a specific Mach-O slice, check that the target
-        # machine can run it before doing any further work.
-        if getattr(context, "arch", None):
-            macho_arch = os.path.normpath(
-                "%s/tools/macho_arch-target" % config.test_source_root
-            )
-            if os.path.exists(macho_arch):
-                r = subprocess.run(
-                    [macho_arch, "--is-supported", context.arch],
-                    capture_output=True,
-                )
-                if r.returncode != 0:
-                    # FIXME: this should be lit.Test.UNSUPPORTED, but lnt
-                    # doesn't support that result code yet.
-                    return lit.Test.Result(
-                        lit.Test.XFAIL,
-                        "Architecture '%s' not supported on this target" % context.arch,
-                    )
 
         plan = litsupport.testplan.TestPlan()
 

--- a/litsupport/test.py
+++ b/litsupport/test.py
@@ -11,6 +11,7 @@ import litsupport.testfile
 import litsupport.testplan
 import os
 import pathlib
+import subprocess
 
 
 # The ResultCode constructor has been changed recently in lit.  An additional parameter has ben added, which
@@ -41,6 +42,26 @@ class TestSuiteTest(lit.formats.ShTest):
         pathlib.Path(tmpBase).parent.mkdir(parents=True, exist_ok=True)
         context = litsupport.testplan.TestContext(test, litConfig, tmpDir, tmpBase)
         litsupport.testfile.parse(context, test.getSourcePath())
+
+        # If the test targets a specific Mach-O slice, check that the target
+        # machine can run it before doing any further work.
+        if getattr(context, "arch", None):
+            macho_arch = os.path.normpath(
+                "%s/tools/macho_arch-target" % config.test_source_root
+            )
+            if os.path.exists(macho_arch):
+                r = subprocess.run(
+                    [macho_arch, "--is-supported", context.arch],
+                    capture_output=True,
+                )
+                if r.returncode != 0:
+                    # FIXME: this should be lit.Test.UNSUPPORTED, but lnt
+                    # doesn't support that result code yet.
+                    return lit.Test.Result(
+                        lit.Test.XFAIL,
+                        "Architecture '%s' not supported on this target" % context.arch,
+                    )
+
         plan = litsupport.testplan.TestPlan()
 
         # Report missing test executables.

--- a/litsupport/testfile.py
+++ b/litsupport/testfile.py
@@ -40,9 +40,12 @@ def parse(context, filename):
     runscript = []
     verifyscript = []
     metricscripts = {}
+    arch = None
     # Note that we keep both "RUN" and "RUN:" in the list to stay compatible
     # with older lit versions.
     keywords = [
+        "ARCH:",
+        "ARCH",
         "PREPARE:",
         "PREPARE",
         "RUN:",
@@ -55,7 +58,9 @@ def parse(context, filename):
     for line_number, command_type, ln in parseIntegratedTestScriptCommands(
         filename, keywords
     ):
-        if command_type.startswith("PREPARE"):
+        if command_type.startswith("ARCH"):
+            arch = ln.strip()
+        elif command_type.startswith("PREPARE"):
             _parseShellCommand(preparescript, ln)
         elif command_type.startswith("RUN"):
             _parseShellCommand(runscript, ln)
@@ -100,6 +105,7 @@ def parse(context, filename):
     context.parsed_runscript = runscript
     context.parsed_verifyscript = verifyscript
     context.parsed_metricscripts = metricscripts
+    context.arch = arch
     context.executable = shellcommand.getMainExecutable(context)
     if not context.executable:
         logging.error("Could not determine executable name in %s" % filename)

--- a/litsupport/testplan.py
+++ b/litsupport/testplan.py
@@ -25,6 +25,7 @@ class TestPlan(object):
         self.profile_files = []
         self.profilescript = []
         self.profilecollectscript = []
+        self.unsupported_exit_codes = []
 
 
 def mutateScript(context, script, mutator):
@@ -105,6 +106,9 @@ def _executePlan(context, plan):
     # Execute RUN: part of the test.
     _, _, exitCode, _ = _executeScript(context, plan.runscript, "run")
     if exitCode != 0:
+        if exitCode in plan.unsupported_exit_codes:
+            # FIXME: lit does not have a lit.Test.UNSUPPORTED yet
+            return lit.Test.XFAIL
         return lit.Test.FAIL
 
     # Execute VERIFY: part of the test.

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -41,3 +41,21 @@ else()
 endif()
 
 add_executable(not ${CMAKE_CURRENT_SOURCE_DIR}/not.cpp)
+
+if(APPLE)
+  add_executable(macho_arch-target ${CMAKE_CURRENT_SOURCE_DIR}/macho_arch.c)
+  llvm_codesign(macho_arch-target)
+  add_executable(build-macho_arch-target ALIAS macho_arch-target)
+  # Ensure that macho_arch is built with at least arm64;arm64e, plus whatever
+  # was already in CMAKE_OSX_ARCHITECTURES.
+  set(_macho_arch_archs ${CMAKE_OSX_ARCHITECTURES} arm64 arm64e)
+  list(REMOVE_DUPLICATES _macho_arch_archs)
+  set_target_properties(macho_arch-target PROPERTIES OSX_ARCHITECTURES "${_macho_arch_archs}")
+  set(_macho_arch_arch_flags)
+  foreach(_arch IN LISTS _macho_arch_archs)
+    list(APPEND _macho_arch_arch_flags -arch ${_arch})
+  endforeach()
+  llvm_add_host_executable(build-macho_arch macho_arch macho_arch.c
+    CPPFLAGS ${_macho_arch_arch_flags}
+    LDFLAGS ${_macho_arch_arch_flags})
+endif()

--- a/tools/macho_arch.c
+++ b/tools/macho_arch.c
@@ -7,22 +7,12 @@
 |*                                                                            *|
 \*===----------------------------------------------------------------------===*/
 
-#include <errno.h>
 #include <mach-o/ldsyms.h>
 #include <mach-o/utils.h>
-#include <mach/machine.h>
 #include <stdio.h>
-#include <string.h>
-#include <sys/sysctl.h>
 
 int main(int argc, const char **argv) {
   if (__builtin_available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)) {
-    if (argc > 2 && strcmp(argv[1], "--is-supported") == 0) {
-      cpu_type_t cpu_type;
-      cpu_subtype_t cpu_subtype;
-      return macho_cpu_type_for_arch_name(argv[2], &cpu_type, &cpu_subtype) ? 0 : 1;
-    }
-
     const char *arch_name = macho_arch_name_for_mach_header(NULL);
     if (!arch_name) {
       fprintf(stderr, "error: unknown cpu type for current process\n");

--- a/tools/macho_arch.c
+++ b/tools/macho_arch.c
@@ -1,0 +1,36 @@
+/*===-- macho_arch.c - LLVM Test Suite Mach-O Support Tool ------*- C++ -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#include <errno.h>
+#include <mach-o/ldsyms.h>
+#include <mach-o/utils.h>
+#include <mach/machine.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/sysctl.h>
+
+int main(int argc, const char **argv) {
+  if (__builtin_available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)) {
+    if (argc > 2 && strcmp(argv[1], "--is-supported") == 0) {
+      cpu_type_t cpu_type;
+      cpu_subtype_t cpu_subtype;
+      return macho_cpu_type_for_arch_name(argv[2], &cpu_type, &cpu_subtype) ? 0 : 1;
+    }
+
+    const char *arch_name = macho_arch_name_for_mach_header(NULL);
+    if (!arch_name) {
+      fprintf(stderr, "error: unknown cpu type for current process\n");
+      return 1;
+    }
+    printf("%s\n", arch_name);
+    return 0;
+  }
+  fprintf(stderr, "error: requires macOS 13.0, iOS 16.0, tvOS 16.0, or watchOS 9.0\n");
+  return 1;
+}

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -38,6 +38,14 @@ add_dependencies(alloc_mem timeit-target)
 llvm_test_run(EXECUTABLE ${Python_EXECUTABLE} "%b/test/test_maxrss.py" "$<TARGET_FILE:timeit-target>" "$<TARGET_FILE:alloc_mem>")
 llvm_add_test_for_target(alloc_mem)
 
+if(APPLE)
+  configure_file(test_arch.py test_arch.py COPYONLY)
+  # Check that timeit -arch correctly selects Mach-O architecture slices.
+  add_dependencies(timeit-target macho_arch-target)
+  llvm_test_run(EXECUTABLE ${Python_EXECUTABLE} "%b/test/test_arch.py" "$<TARGET_FILE:timeit-target>" "$<TARGET_FILE:macho_arch-target>")
+  llvm_add_test_for_target(timeit-target)
+endif()
+
 # Check that fpcmp can handle decimal numbers ending with a period correctly.
 llvm_test_run(EXECUTABLE "$<TARGET_FILE:fpcmp-target>" "-a" "0.03" "-r" "0.03" "-i" "%b/test/fpcmp-input1" "%b/test/fpcmp-input2")
 llvm_add_test_for_target(fpcmp-target)

--- a/tools/test/test_arch.py
+++ b/tools/test/test_arch.py
@@ -1,0 +1,50 @@
+"""Test that timeit -arch correctly selects Mach-O slices on macOS.
+
+Usage: test_arch.py <timeit> <macho_arch>
+"""
+import subprocess
+import sys
+
+
+def test_valid_arches(timeit, exe):
+    """Check that timeit -arch <slice> runs the correct slice of exe."""
+
+    lipo = subprocess.run(["lipo", "-archs", exe], capture_output=True, text=True)
+    if lipo.returncode != 0:
+        print(f"lipo failed: {lipo.stderr.strip()}")
+        sys.exit(1)
+
+    for arch in lipo.stdout.split():
+        if subprocess.run([exe, "--is-supported", arch], capture_output=True).returncode != 0:
+            print(f"skipping {arch}: not supported on this host")
+            continue
+        cmd = [timeit, "-arch", arch, exe]
+        print(" ".join(cmd))
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(f"timeit -arch {arch} exited with {result.returncode}")
+            print(result.stderr)
+            sys.exit(1)
+        got = result.stdout.strip()
+        if got != arch:
+            print(f"timeit -arch {arch}: expected '{arch}', got '{got}'")
+            sys.exit(1)
+
+
+def test_invalid_arch(timeit, exe):
+    """Check that timeit rejects unrecognized arch names."""
+
+    cmd = [timeit, "-arch", "obviouslyfake", exe]
+    print(" ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True)
+    if result.returncode == 0:
+        print("timeit -arch obviouslyfake should have failed but succeeded")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    timeit = sys.argv[1]
+    macho_arch = sys.argv[2]
+
+    test_valid_arches(timeit, macho_arch)
+    test_invalid_arch(timeit, macho_arch)

--- a/tools/test/test_arch.py
+++ b/tools/test/test_arch.py
@@ -1,9 +1,12 @@
 """Test that timeit -arch correctly selects Mach-O slices on macOS.
 
-Usage: test_arch.py <timeit> <macho_arch>
+Usage: test_arch.py <timeit> <exe>
 """
 import subprocess
 import sys
+
+# Must match EXITCODE_EXEC_BADARCH in tools/timeit.c
+_EXITCODE_EXEC_BADARCH = 70
 
 
 def test_valid_arches(timeit, exe):
@@ -15,12 +18,12 @@ def test_valid_arches(timeit, exe):
         sys.exit(1)
 
     for arch in lipo.stdout.split():
-        if subprocess.run([exe, "--is-supported", arch], capture_output=True).returncode != 0:
-            print(f"skipping {arch}: not supported on this host")
-            continue
         cmd = [timeit, "-arch", arch, exe]
         print(" ".join(cmd))
         result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode == _EXITCODE_EXEC_BADARCH:
+            print(f"skipping {arch}: not supported on this machine")
+            continue
         if result.returncode != 0:
             print(f"timeit -arch {arch} exited with {result.returncode}")
             print(result.stderr)
@@ -44,7 +47,7 @@ def test_invalid_arch(timeit, exe):
 
 if __name__ == "__main__":
     timeit = sys.argv[1]
-    macho_arch = sys.argv[2]
+    exe = sys.argv[2]
 
-    test_valid_arches(timeit, macho_arch)
-    test_invalid_arch(timeit, macho_arch)
+    test_valid_arches(timeit, exe)
+    test_invalid_arch(timeit, exe)

--- a/tools/timeit.c
+++ b/tools/timeit.c
@@ -41,6 +41,7 @@ enum ExitCode {
   EXITCODE_EXEC_FAILURE = 67,
   EXITCODE_EXEC_NOENTRY = 127,
   EXITCODE_EXEC_NOPERMISSION = 126,
+  EXITCODE_EXEC_BADARCH = 70,
 
   /* \brief Indicates that we were unexpectedly signalled(). */
   EXITCODE_SIGNALLED = 68,
@@ -766,6 +767,8 @@ static int execute_target_process(char *const argv[]) {
         return EXITCODE_EXEC_NOENTRY;
       case EACCES:
         return EXITCODE_EXEC_NOPERMISSION;
+      case EBADARCH:
+        return EXITCODE_EXEC_BADARCH;
       default:
         return EXITCODE_EXEC_FAILURE;
       }

--- a/tools/timeit.c
+++ b/tools/timeit.c
@@ -24,6 +24,13 @@
 #include <sys/wait.h>
 #endif
 
+#ifdef __APPLE__
+#include <mach/machine.h>
+#include <mach-o/utils.h>
+#include <spawn.h>
+extern char **environ;
+#endif
+
 /* Enumeration for our exit status codes. */
 enum ExitCode {
   /* \brief Indicates a failure monitoring the target. */
@@ -86,6 +93,11 @@ static int g_append_exitstats = 0;
 
 /* \brief If non-zero, report maxrss in summary file and non-POSIX output. */
 static int g_report_maxrss = 0;
+
+#ifdef __APPLE__
+/* \brief If non-null, run the target as this architecture slice. */
+static const char *g_arch_slice = 0;
+#endif
 
 #ifdef _WIN32
 /* \brief If platform does not define rlim_t type, then define it as int. */
@@ -732,6 +744,38 @@ static int execute_target_process(char *const argv[]) {
     }
   }
 
+#ifdef __APPLE__
+  if (/*macho_cpu_type_for_arch_name*/__builtin_available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)) {
+    if (g_arch_slice) {
+      cpu_type_t cpu_type = 0;
+      cpu_subtype_t cpu_subtype = 0;
+      if (!macho_cpu_type_for_arch_name(g_arch_slice, &cpu_type, &cpu_subtype)) {
+        fprintf(stderr, "%s: error: unknown arch '%s'\n", g_program_name,
+                g_arch_slice);
+        return EXITCODE_EXEC_FAILURE;
+      }
+      posix_spawnattr_t spawnattr;
+      posix_spawnattr_init(&spawnattr);
+      posix_spawnattr_setflags(&spawnattr, POSIX_SPAWN_SETEXEC);
+      posix_spawnattr_setarchpref_np(&spawnattr, 1, &cpu_type, &cpu_subtype, NULL);
+      int err = posix_spawn(NULL, argv[0], NULL, &spawnattr, argv, environ);
+      posix_spawnattr_destroy(&spawnattr);
+      fprintf(stderr, "posix_spawn: %s\n", strerror(err));
+      switch (err) {
+      case ENOENT:
+        return EXITCODE_EXEC_NOENTRY;
+      case EACCES:
+        return EXITCODE_EXEC_NOPERMISSION;
+      default:
+        return EXITCODE_EXEC_FAILURE;
+      }
+    }
+  } else if (g_arch_slice) {
+    fprintf(stderr, "%s: warning: -arch ignored (requires macOS 13.0, iOS 16.0, tvOS 16.0, or watchOS 9.0)\n",
+            g_program_name);
+  }
+#endif
+
   execvp(argv[0], argv);
   perror("execv");
 
@@ -834,6 +878,10 @@ static void usage(int is_error) {
   fprintf(stderr, "  %-20s %s", "--report-maxrss",
           WRAPPED
           "Report maximum resident set size (Currently Apple/Linux only, silently ignored on unsupported platforms).\n");
+#ifdef __APPLE__
+  fprintf(stderr, "  %-20s %s", "-arch <arch>",
+          "Execute the target as the given Mach-O arch slice.\n");
+#endif
   _exit(is_error);
 }
 
@@ -920,6 +968,17 @@ int main(int argc, char * const argv[]) {
       g_report_maxrss = 1;
       continue;
     }
+
+#ifdef __APPLE__
+    if (streq(arg, "-arch")) {
+      if (i + 1 == argc) {
+        fprintf(stderr, "error: %s argument requires an option\n", arg);
+        usage(/*is_error=*/1);
+      }
+      g_arch_slice = argv[++i];
+      continue;
+    }
+#endif
 
     if (streq(arg, "-c") || streq(arg, "--chdir")) {
       if (i + 1 == argc) {


### PR DESCRIPTION
This is enabled through a new CMake variable `TEST_SUITE_RUN_ARCHS` that allows users to specify which subset arches from CMAKE_OSX_ARCHITECTURES they'd like to run the tests for. By default, when there's two or more, we emit foo.<slice>.test files for all of them. Existing names are preserved when TEST_SUITE_RUN_ARCHS is a list of size zero or one.

Implementation-wise, we extend the `timeit` binary to support `-arch <slice>`, much like macOS's `arch` utility, and plumb in the requested slice name via a new `ARCH:` directive in the .test files.