### PR TITLE
Add MicroBenchmark for Small Trip Count Loop vectorization

### DIFF
--- a/MicroBenchmarks/LoopVectorization/CMakeLists.txt
+++ b/MicroBenchmarks/LoopVectorization/CMakeLists.txt
@@ -14,6 +14,7 @@ llvm_test_executable(LoopVectorizationBenchmarks
   main.cpp
   MathFunctions.cpp
   RuntimeChecks.cpp
+  SmallLoopTripCount.cpp
   VectorOperations.cpp
   EarlyExit.cpp
 )

--- a/MicroBenchmarks/LoopVectorization/SmallLoopTripCount.cpp
+++ b/MicroBenchmarks/LoopVectorization/SmallLoopTripCount.cpp
@@ -1,0 +1,102 @@
+// This program tests the performance impact of vectorization in loops with
+// small trip counts. These cases exercise the LoopVectorize path that accepts
+// trip counts one larger than the vectorization factor.
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+#include "benchmark/benchmark.h"
+
+#define NOINLINE __attribute__((noinline))
+#define LOOP_VECTORIZE_ENABLE                                                  \
+  _Pragma("clang loop vectorize(enable) unroll(disable)")
+#define LOOP_VECTORIZE_DISABLE                                                 \
+  _Pragma("clang loop vectorize(disable) interleave(disable) unroll(disable)")
+#define LOOP_INTERLEAVE_COUNT_2                                                \
+  _Pragma("clang loop vectorize(enable) interleave_count(2) unroll(disable)")
+
+static uint64_t g_small_loop_trip_count_sum = 0;
+
+template <typename Ty>
+NOINLINE void loopTc5Vector(const Ty *__restrict A, Ty *__restrict B) {
+  LOOP_VECTORIZE_ENABLE
+  for (uint64_t I = 0; I != 5; ++I)
+    B[I] = A[I] + static_cast<Ty>(1);
+}
+
+template <typename Ty>
+NOINLINE void loopTc5Scalar(const Ty *__restrict A, Ty *__restrict B) {
+  LOOP_VECTORIZE_DISABLE
+  for (uint64_t I = 0; I != 5; ++I)
+    B[I] = A[I] + static_cast<Ty>(1);
+}
+
+NOINLINE void loopTc5I64InterleaveCount2Vector(const uint64_t *__restrict A,
+                                               uint64_t *__restrict B) {
+  LOOP_INTERLEAVE_COUNT_2
+  for (uint64_t I = 0; I != 5; ++I)
+    B[I] = A[I] + 1;
+}
+
+template <typename Ty> using KernelFn = void (*)(const Ty *, Ty *);
+
+template <typename Ty> static void initData(std::array<Ty, 16> &A) {
+  for (size_t I = 0; I != A.size(); ++I)
+    A[I] = static_cast<Ty>(0x0102030405060708ULL + I);
+}
+
+template <typename Ty> static uint64_t checksum(const std::array<Ty, 16> &A) {
+  uint64_t Sum = 0;
+  for (size_t I = 0; I != 5; ++I) {
+    auto Value = static_cast<uint64_t>(A[I]);
+    for (size_t Byte = 0; Byte != sizeof(Ty); ++Byte) {
+      Sum = Sum * 131 + (Value & std::numeric_limits<uint8_t>::max());
+      Value >>= 8;
+    }
+  }
+  return Sum;
+}
+
+template <typename Ty>
+static void runBenchForSmallLoopTripCount(benchmark::State &State,
+                                          KernelFn<Ty> Fn) {
+  std::array<Ty, 16> A;
+  std::array<Ty, 16> B = {};
+  initData(A);
+
+  for (auto _ : State) {
+    benchmark::DoNotOptimize(A.data());
+    benchmark::DoNotOptimize(B.data());
+    Fn(A.data(), B.data());
+    benchmark::ClobberMemory();
+  }
+
+  g_small_loop_trip_count_sum ^= checksum(B);
+  benchmark::DoNotOptimize(g_small_loop_trip_count_sum);
+  State.SetItemsProcessed(State.iterations() * 5);
+}
+
+template <typename Ty> void benchTc5Vector(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc5Vector<Ty>);
+}
+
+template <typename Ty> void benchTc5Scalar(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc5Scalar<Ty>);
+}
+
+void benchTc5I64InterleaveCount2Vector(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<uint64_t>(State,
+                                          loopTc5I64InterleaveCount2Vector);
+}
+
+BENCHMARK_TEMPLATE(benchTc5Vector, uint8_t)->Name("tc5/i8/vector");
+BENCHMARK_TEMPLATE(benchTc5Scalar, uint8_t)->Name("tc5/i8/scalar");
+BENCHMARK_TEMPLATE(benchTc5Vector, uint16_t)->Name("tc5/i16/vector");
+BENCHMARK_TEMPLATE(benchTc5Scalar, uint16_t)->Name("tc5/i16/scalar");
+BENCHMARK_TEMPLATE(benchTc5Vector, uint32_t)->Name("tc5/i32/vector");
+BENCHMARK_TEMPLATE(benchTc5Scalar, uint32_t)->Name("tc5/i32/scalar");
+BENCHMARK_TEMPLATE(benchTc5Vector, uint64_t)->Name("tc5/i64/vector");
+BENCHMARK_TEMPLATE(benchTc5Scalar, uint64_t)->Name("tc5/i64/scalar");
+BENCHMARK(benchTc5I64InterleaveCount2Vector)->Name("tc5/i64/ic2/vector");

--- a/MicroBenchmarks/LoopVectorization/SmallLoopTripCount.cpp
+++ b/MicroBenchmarks/LoopVectorization/SmallLoopTripCount.cpp
@@ -80,6 +80,38 @@ NOINLINE void loopTc3I64InterleaveCount2Vector(const Ty *__restrict A,
     B[I] = A[I] + static_cast<Ty>(1);
 }
 
+template <typename Ty>
+NOINLINE void loopTc3SelectionVector(const Ty *__restrict A, Ty *__restrict B) {
+  LOOP_VECTORIZE_ENABLE
+  for (int i = 0; i < 3; i++) {
+    B[i] = B[i] < A[i] ? B[i] : A[i];
+  }
+}
+
+template <typename Ty>
+NOINLINE void loopTc3SelectionScalar(const Ty *__restrict A, Ty *__restrict B) {
+  LOOP_VECTORIZE_DISABLE
+  for (int i = 0; i < 3; i++) {
+    B[i] = B[i] < A[i] ? B[i] : A[i];
+  }
+}
+
+template <typename Ty>
+NOINLINE void loopTc5ModulusVector(const Ty *__restrict A, Ty *__restrict B) {
+  LOOP_VECTORIZE_ENABLE
+  for (int i = 0; i < 5; i++) {
+    B[i] %= (A[i] | 1);
+  }
+}
+
+template <typename Ty>
+NOINLINE void loopTc5ModulusScalar(const Ty *__restrict A, Ty *__restrict B) {
+  LOOP_VECTORIZE_DISABLE
+  for (int i = 0; i < 5; i++) {
+    B[i] %= (A[i] | 1);
+  }
+}
+
 template <typename Ty> using KernelFn = void (*)(const Ty *, Ty *);
 
 template <typename Ty> static void initData(std::array<Ty, 16> &A) {
@@ -140,6 +172,24 @@ void benchTc3I64InterleaveCount2Vector(benchmark::State &State) {
                                     loopTc3I64InterleaveCount2Vector<Ty>);
 }
 
+template <typename Ty>
+void benchloopTc3SelectionVector(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc3SelectionVector<Ty>);
+}
+
+template <typename Ty>
+void benchloopTc3SelectionScalar(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc3SelectionScalar<Ty>);
+}
+
+template <typename Ty> void benchloopTc5ModulusVector(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc5ModulusVector<Ty>);
+}
+
+template <typename Ty> void benchloopTc5ModulusScalar(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc5ModulusScalar<Ty>);
+}
+
 BENCHMARK_TEMPLATE(benchTc5Vector, uint8_t)->Name("tc5/i8/vector");
 BENCHMARK_TEMPLATE(benchTc5Scalar, uint8_t)->Name("tc5/i8/scalar");
 BENCHMARK_TEMPLATE(benchTc5Vector, uint16_t)->Name("tc5/i16/vector");
@@ -165,3 +215,15 @@ BENCHMARK_TEMPLATE(benchTc3Vector, uint64_t)->Name("tc3/i64/vector");
 BENCHMARK_TEMPLATE(benchTc3Scalar, uint64_t)->Name("tc3/i64/scalar");
 BENCHMARK_TEMPLATE(benchTc3I64InterleaveCount2Vector, uint64_t)
     ->Name("tc3/i64/ic2/vector");
+BENCHMARK_TEMPLATE(benchloopTc3SelectionVector, int8_t)
+    ->Name("tc3Selection/i8/vector");
+BENCHMARK_TEMPLATE(benchloopTc3SelectionScalar, int8_t)
+    ->Name("tc3Selection/i8/scalar");
+BENCHMARK_TEMPLATE(benchloopTc3SelectionVector, int16_t)
+    ->Name("tc3Selection/i16/vector");
+BENCHMARK_TEMPLATE(benchloopTc3SelectionScalar, int16_t)
+    ->Name("tc3Selection/i16/scalar");
+BENCHMARK_TEMPLATE(benchloopTc5ModulusVector, int32_t)
+    ->Name("tc5Modulus/i32/vector");
+BENCHMARK_TEMPLATE(benchloopTc5ModulusScalar, int32_t)
+    ->Name("tc5Modulus/i32/scalar");

--- a/MicroBenchmarks/LoopVectorization/SmallLoopTripCount.cpp
+++ b/MicroBenchmarks/LoopVectorization/SmallLoopTripCount.cpp
@@ -97,6 +97,22 @@ NOINLINE void loopTc3SelectionScalar(const Ty *__restrict A, Ty *__restrict B) {
 }
 
 template <typename Ty>
+NOINLINE void loopTc5PowerVector(const Ty *__restrict A, Ty *__restrict B) {
+  LOOP_VECTORIZE_ENABLE
+  for (int i = 0; i < 5; i++) {
+    B[i] ^= A[i];
+  }
+}
+
+template <typename Ty>
+NOINLINE void loopTc5PowerScalar(const Ty *__restrict A, Ty *__restrict B) {
+  LOOP_VECTORIZE_DISABLE
+  for (int i = 0; i < 5; i++) {
+    B[i] ^= A[i];
+  }
+}
+
+template <typename Ty>
 NOINLINE void loopTc5ModulusVector(const Ty *__restrict A, Ty *__restrict B) {
   LOOP_VECTORIZE_ENABLE
   for (int i = 0; i < 5; i++) {
@@ -182,6 +198,14 @@ void benchloopTc3SelectionScalar(benchmark::State &State) {
   runBenchForSmallLoopTripCount<Ty>(State, loopTc3SelectionScalar<Ty>);
 }
 
+template <typename Ty> void benchloopTC5PowerVector(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc5PowerVector<Ty>);
+}
+
+template <typename Ty> void benchloopTC5PowerScalar(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc5PowerScalar<Ty>);
+}
+
 template <typename Ty> void benchloopTc5ModulusVector(benchmark::State &State) {
   runBenchForSmallLoopTripCount<Ty>(State, loopTc5ModulusVector<Ty>);
 }
@@ -223,6 +247,12 @@ BENCHMARK_TEMPLATE(benchloopTc3SelectionVector, int16_t)
     ->Name("tc3Selection/i16/vector");
 BENCHMARK_TEMPLATE(benchloopTc3SelectionScalar, int16_t)
     ->Name("tc3Selection/i16/scalar");
+BENCHMARK_TEMPLATE(benchloopTC5PowerVector, int8_t)->Name("tc5Power/i8/vector");
+BENCHMARK_TEMPLATE(benchloopTC5PowerScalar, int8_t)->Name("tc5Power/i8/scalar");
+BENCHMARK_TEMPLATE(benchloopTC5PowerVector, int16_t)
+    ->Name("tc5Power/i16/vector");
+BENCHMARK_TEMPLATE(benchloopTC5PowerScalar, int16_t)
+    ->Name("tc5Power/i16/scalar");
 BENCHMARK_TEMPLATE(benchloopTc5ModulusVector, int32_t)
     ->Name("tc5Modulus/i32/vector");
 BENCHMARK_TEMPLATE(benchloopTc5ModulusScalar, int32_t)

--- a/MicroBenchmarks/LoopVectorization/SmallLoopTripCount.cpp
+++ b/MicroBenchmarks/LoopVectorization/SmallLoopTripCount.cpp
@@ -31,7 +31,8 @@ NOINLINE void loopTc5Scalar(const Ty *__restrict A, Ty *__restrict B) {
 }
 
 template <typename Ty>
-NOINLINE void loopTc5I64InterleaveCount2Vector(const Ty *__restrict A, Ty *__restrict B) {
+NOINLINE void loopTc5I64InterleaveCount2Vector(const Ty *__restrict A,
+                                               Ty *__restrict B) {
   LOOP_INTERLEAVE_COUNT_2
   for (uint64_t I = 0; I != 5; ++I)
     B[I] = A[I] + static_cast<Ty>(1);
@@ -72,12 +73,12 @@ NOINLINE void loopTc3Scalar(const Ty *__restrict A, Ty *__restrict B) {
 }
 
 template <typename Ty>
-NOINLINE void loopTc3I64InterleaveCount2Vector(const Ty *__restrict A, Ty *__restrict B) {
+NOINLINE void loopTc3I64InterleaveCount2Vector(const Ty *__restrict A,
+                                               Ty *__restrict B) {
   LOOP_INTERLEAVE_COUNT_2
   for (uint64_t I = 0; I != 3; ++I)
     B[I] = A[I] + static_cast<Ty>(1);
 }
-
 
 template <typename Ty> using KernelFn = void (*)(const Ty *, Ty *);
 
@@ -109,9 +110,10 @@ template <typename Ty> void benchTc5Scalar(benchmark::State &State) {
   runBenchForSmallLoopTripCount<Ty>(State, loopTc5Scalar<Ty>);
 }
 
-template <typename Ty> void benchTc5I64InterleaveCount2Vector(benchmark::State &State) {
+template <typename Ty>
+void benchTc5I64InterleaveCount2Vector(benchmark::State &State) {
   runBenchForSmallLoopTripCount<Ty>(State,
-                                          loopTc5I64InterleaveCount2Vector<Ty>);
+                                    loopTc5I64InterleaveCount2Vector<Ty>);
 }
 
 template <typename Ty>
@@ -132,9 +134,10 @@ template <typename Ty> void benchTc3Scalar(benchmark::State &State) {
   runBenchForSmallLoopTripCount<Ty>(State, loopTc3Scalar<Ty>);
 }
 
-template <typename Ty> void benchTc3I64InterleaveCount2Vector(benchmark::State &State) {
+template <typename Ty>
+void benchTc3I64InterleaveCount2Vector(benchmark::State &State) {
   runBenchForSmallLoopTripCount<Ty>(State,
-                                          loopTc3I64InterleaveCount2Vector<Ty>);
+                                    loopTc3I64InterleaveCount2Vector<Ty>);
 }
 
 BENCHMARK_TEMPLATE(benchTc5Vector, uint8_t)->Name("tc5/i8/vector");
@@ -145,9 +148,12 @@ BENCHMARK_TEMPLATE(benchTc5Vector, uint32_t)->Name("tc5/i32/vector");
 BENCHMARK_TEMPLATE(benchTc5Scalar, uint32_t)->Name("tc5/i32/scalar");
 BENCHMARK_TEMPLATE(benchTc5Vector, uint64_t)->Name("tc5/i64/vector");
 BENCHMARK_TEMPLATE(benchTc5Scalar, uint64_t)->Name("tc5/i64/scalar");
-BENCHMARK_TEMPLATE(benchTc5I64InterleaveCount2Vector, uint64_t)->Name("tc5/i64/ic2/vector");
-BENCHMARK_TEMPLATE(benchTc5ScalarizedDivVector, uint64_t)->Name("tc5/i64/scalarized-div/vector");
-BENCHMARK_TEMPLATE(benchTc5ScalarizedDivScalar, uint64_t)->Name("tc5/i64/scalarized-div/scalar");
+BENCHMARK_TEMPLATE(benchTc5I64InterleaveCount2Vector, uint64_t)
+    ->Name("tc5/i64/ic2/vector");
+BENCHMARK_TEMPLATE(benchTc5ScalarizedDivVector, uint64_t)
+    ->Name("tc5/i64/scalarized-div/vector");
+BENCHMARK_TEMPLATE(benchTc5ScalarizedDivScalar, uint64_t)
+    ->Name("tc5/i64/scalarized-div/scalar");
 
 BENCHMARK_TEMPLATE(benchTc3Vector, uint8_t)->Name("tc3/i8/vector");
 BENCHMARK_TEMPLATE(benchTc3Scalar, uint8_t)->Name("tc3/i8/scalar");
@@ -157,4 +163,5 @@ BENCHMARK_TEMPLATE(benchTc3Vector, uint32_t)->Name("tc3/i32/vector");
 BENCHMARK_TEMPLATE(benchTc3Scalar, uint32_t)->Name("tc3/i32/scalar");
 BENCHMARK_TEMPLATE(benchTc3Vector, uint64_t)->Name("tc3/i64/vector");
 BENCHMARK_TEMPLATE(benchTc3Scalar, uint64_t)->Name("tc3/i64/scalar");
-BENCHMARK_TEMPLATE(benchTc3I64InterleaveCount2Vector, uint64_t)->Name("tc3/i64/ic2/vector");
+BENCHMARK_TEMPLATE(benchTc3I64InterleaveCount2Vector, uint64_t)
+    ->Name("tc3/i64/ic2/vector");

--- a/MicroBenchmarks/LoopVectorization/SmallLoopTripCount.cpp
+++ b/MicroBenchmarks/LoopVectorization/SmallLoopTripCount.cpp
@@ -5,7 +5,6 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 
 #include "benchmark/benchmark.h"
 
@@ -16,8 +15,6 @@
   _Pragma("clang loop vectorize(disable) interleave(disable) unroll(disable)")
 #define LOOP_INTERLEAVE_COUNT_2                                                \
   _Pragma("clang loop vectorize(enable) interleave_count(2) unroll(disable)")
-
-static uint64_t g_small_loop_trip_count_sum = 0;
 
 template <typename Ty>
 NOINLINE void loopTc5Vector(const Ty *__restrict A, Ty *__restrict B) {
@@ -33,30 +30,60 @@ NOINLINE void loopTc5Scalar(const Ty *__restrict A, Ty *__restrict B) {
     B[I] = A[I] + static_cast<Ty>(1);
 }
 
-NOINLINE void loopTc5I64InterleaveCount2Vector(const uint64_t *__restrict A,
-                                               uint64_t *__restrict B) {
+template <typename Ty>
+NOINLINE void loopTc5I64InterleaveCount2Vector(const Ty *__restrict A, Ty *__restrict B) {
   LOOP_INTERLEAVE_COUNT_2
   for (uint64_t I = 0; I != 5; ++I)
-    B[I] = A[I] + 1;
+    B[I] = A[I] + static_cast<Ty>(1);
 }
+
+template <typename Ty>
+NOINLINE void loopTc5ScalarizedDivVector(const Ty *__restrict A,
+                                         Ty *__restrict B) {
+  LOOP_VECTORIZE_ENABLE
+  for (uint64_t I = 0; I != 5; ++I) {
+    Ty Den = (A[I] & static_cast<Ty>(15)) + static_cast<Ty>(1);
+    B[I] = (A[I] * static_cast<Ty>(13)) / Den;
+  }
+}
+
+template <typename Ty>
+NOINLINE void loopTc5ScalarizedDivScalar(const Ty *__restrict A,
+                                         Ty *__restrict B) {
+  LOOP_VECTORIZE_DISABLE
+  for (uint64_t I = 0; I != 5; ++I) {
+    Ty Den = (A[I] & static_cast<Ty>(15)) + static_cast<Ty>(1);
+    B[I] = (A[I] * static_cast<Ty>(13)) / Den;
+  }
+}
+
+template <typename Ty>
+NOINLINE void loopTc3Vector(const Ty *__restrict A, Ty *__restrict B) {
+  LOOP_VECTORIZE_ENABLE
+  for (uint64_t I = 0; I != 3; ++I)
+    B[I] = A[I] + static_cast<Ty>(1);
+}
+
+template <typename Ty>
+NOINLINE void loopTc3Scalar(const Ty *__restrict A, Ty *__restrict B) {
+  LOOP_VECTORIZE_DISABLE
+  for (uint64_t I = 0; I != 3; ++I)
+    B[I] = A[I] + static_cast<Ty>(1);
+}
+
+template <typename Ty>
+NOINLINE void loopTc3I64InterleaveCount2Vector(const Ty *__restrict A, Ty *__restrict B) {
+  LOOP_INTERLEAVE_COUNT_2
+  for (uint64_t I = 0; I != 3; ++I)
+    B[I] = A[I] + static_cast<Ty>(1);
+}
+
 
 template <typename Ty> using KernelFn = void (*)(const Ty *, Ty *);
 
 template <typename Ty> static void initData(std::array<Ty, 16> &A) {
   for (size_t I = 0; I != A.size(); ++I)
     A[I] = static_cast<Ty>(0x0102030405060708ULL + I);
-}
-
-template <typename Ty> static uint64_t checksum(const std::array<Ty, 16> &A) {
-  uint64_t Sum = 0;
-  for (size_t I = 0; I != 5; ++I) {
-    auto Value = static_cast<uint64_t>(A[I]);
-    for (size_t Byte = 0; Byte != sizeof(Ty); ++Byte) {
-      Sum = Sum * 131 + (Value & std::numeric_limits<uint8_t>::max());
-      Value >>= 8;
-    }
-  }
-  return Sum;
 }
 
 template <typename Ty>
@@ -72,10 +99,6 @@ static void runBenchForSmallLoopTripCount(benchmark::State &State,
     Fn(A.data(), B.data());
     benchmark::ClobberMemory();
   }
-
-  g_small_loop_trip_count_sum ^= checksum(B);
-  benchmark::DoNotOptimize(g_small_loop_trip_count_sum);
-  State.SetItemsProcessed(State.iterations() * 5);
 }
 
 template <typename Ty> void benchTc5Vector(benchmark::State &State) {
@@ -86,9 +109,32 @@ template <typename Ty> void benchTc5Scalar(benchmark::State &State) {
   runBenchForSmallLoopTripCount<Ty>(State, loopTc5Scalar<Ty>);
 }
 
-void benchTc5I64InterleaveCount2Vector(benchmark::State &State) {
-  runBenchForSmallLoopTripCount<uint64_t>(State,
-                                          loopTc5I64InterleaveCount2Vector);
+template <typename Ty> void benchTc5I64InterleaveCount2Vector(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State,
+                                          loopTc5I64InterleaveCount2Vector<Ty>);
+}
+
+template <typename Ty>
+void benchTc5ScalarizedDivVector(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc5ScalarizedDivVector<Ty>);
+}
+
+template <typename Ty>
+void benchTc5ScalarizedDivScalar(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc5ScalarizedDivScalar<Ty>);
+}
+
+template <typename Ty> void benchTc3Vector(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc3Vector<Ty>);
+}
+
+template <typename Ty> void benchTc3Scalar(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc3Scalar<Ty>);
+}
+
+template <typename Ty> void benchTc3I64InterleaveCount2Vector(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State,
+                                          loopTc3I64InterleaveCount2Vector<Ty>);
 }
 
 BENCHMARK_TEMPLATE(benchTc5Vector, uint8_t)->Name("tc5/i8/vector");
@@ -99,4 +145,16 @@ BENCHMARK_TEMPLATE(benchTc5Vector, uint32_t)->Name("tc5/i32/vector");
 BENCHMARK_TEMPLATE(benchTc5Scalar, uint32_t)->Name("tc5/i32/scalar");
 BENCHMARK_TEMPLATE(benchTc5Vector, uint64_t)->Name("tc5/i64/vector");
 BENCHMARK_TEMPLATE(benchTc5Scalar, uint64_t)->Name("tc5/i64/scalar");
-BENCHMARK(benchTc5I64InterleaveCount2Vector)->Name("tc5/i64/ic2/vector");
+BENCHMARK_TEMPLATE(benchTc5I64InterleaveCount2Vector, uint64_t)->Name("tc5/i64/ic2/vector");
+BENCHMARK_TEMPLATE(benchTc5ScalarizedDivVector, uint64_t)->Name("tc5/i64/scalarized-div/vector");
+BENCHMARK_TEMPLATE(benchTc5ScalarizedDivScalar, uint64_t)->Name("tc5/i64/scalarized-div/scalar");
+
+BENCHMARK_TEMPLATE(benchTc3Vector, uint8_t)->Name("tc3/i8/vector");
+BENCHMARK_TEMPLATE(benchTc3Scalar, uint8_t)->Name("tc3/i8/scalar");
+BENCHMARK_TEMPLATE(benchTc3Vector, uint16_t)->Name("tc3/i16/vector");
+BENCHMARK_TEMPLATE(benchTc3Scalar, uint16_t)->Name("tc3/i16/scalar");
+BENCHMARK_TEMPLATE(benchTc3Vector, uint32_t)->Name("tc3/i32/vector");
+BENCHMARK_TEMPLATE(benchTc3Scalar, uint32_t)->Name("tc3/i32/scalar");
+BENCHMARK_TEMPLATE(benchTc3Vector, uint64_t)->Name("tc3/i64/vector");
+BENCHMARK_TEMPLATE(benchTc3Scalar, uint64_t)->Name("tc3/i64/scalar");
+BENCHMARK_TEMPLATE(benchTc3I64InterleaveCount2Vector, uint64_t)->Name("tc3/i64/ic2/vector");

--- a/MicroBenchmarks/LoopVectorization/SmallLoopTripCount.cpp
+++ b/MicroBenchmarks/LoopVectorization/SmallLoopTripCount.cpp
@@ -97,7 +97,8 @@ NOINLINE void loopTc3SelectionScalar(const Ty *__restrict A, Ty *__restrict B) {
 }
 
 template <typename Ty>
-NOINLINE void loopTc5PowerVector(const Ty *__restrict A, Ty *__restrict B) {
+NOINLINE void loopTc5BitwiseXOrVector(const Ty *__restrict A,
+                                      Ty *__restrict B) {
   LOOP_VECTORIZE_ENABLE
   for (int i = 0; i < 5; i++) {
     B[i] ^= A[i];
@@ -105,7 +106,8 @@ NOINLINE void loopTc5PowerVector(const Ty *__restrict A, Ty *__restrict B) {
 }
 
 template <typename Ty>
-NOINLINE void loopTc5PowerScalar(const Ty *__restrict A, Ty *__restrict B) {
+NOINLINE void loopTc5BitwiseXOrScalar(const Ty *__restrict A,
+                                      Ty *__restrict B) {
   LOOP_VECTORIZE_DISABLE
   for (int i = 0; i < 5; i++) {
     B[i] ^= A[i];
@@ -198,12 +200,14 @@ void benchloopTc3SelectionScalar(benchmark::State &State) {
   runBenchForSmallLoopTripCount<Ty>(State, loopTc3SelectionScalar<Ty>);
 }
 
-template <typename Ty> void benchloopTC5PowerVector(benchmark::State &State) {
-  runBenchForSmallLoopTripCount<Ty>(State, loopTc5PowerVector<Ty>);
+template <typename Ty>
+void benchloopTC5BitwiseXOrVector(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc5BitwiseXOrVector<Ty>);
 }
 
-template <typename Ty> void benchloopTC5PowerScalar(benchmark::State &State) {
-  runBenchForSmallLoopTripCount<Ty>(State, loopTc5PowerScalar<Ty>);
+template <typename Ty>
+void benchloopTC5BitwiseXOrScalar(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc5BitwiseXOrScalar<Ty>);
 }
 
 template <typename Ty> void benchloopTc5ModulusVector(benchmark::State &State) {
@@ -247,12 +251,14 @@ BENCHMARK_TEMPLATE(benchloopTc3SelectionVector, int16_t)
     ->Name("tc3Selection/i16/vector");
 BENCHMARK_TEMPLATE(benchloopTc3SelectionScalar, int16_t)
     ->Name("tc3Selection/i16/scalar");
-BENCHMARK_TEMPLATE(benchloopTC5PowerVector, int8_t)->Name("tc5Power/i8/vector");
-BENCHMARK_TEMPLATE(benchloopTC5PowerScalar, int8_t)->Name("tc5Power/i8/scalar");
-BENCHMARK_TEMPLATE(benchloopTC5PowerVector, int16_t)
-    ->Name("tc5Power/i16/vector");
-BENCHMARK_TEMPLATE(benchloopTC5PowerScalar, int16_t)
-    ->Name("tc5Power/i16/scalar");
+BENCHMARK_TEMPLATE(benchloopTC5BitwiseXOrVector, int8_t)
+    ->Name("tc5BitwideXor/i8/vector");
+BENCHMARK_TEMPLATE(benchloopTC5BitwiseXOrScalar, int8_t)
+    ->Name("tc5BitwideXor/i8/scalar");
+BENCHMARK_TEMPLATE(benchloopTC5BitwiseXOrVector, int16_t)
+    ->Name("tc5BitwideXor/i16/vector");
+BENCHMARK_TEMPLATE(benchloopTC5BitwiseXOrScalar, int16_t)
+    ->Name("tc5BitwideXor/i16/scalar");
 BENCHMARK_TEMPLATE(benchloopTc5ModulusVector, int32_t)
     ->Name("tc5Modulus/i32/vector");
 BENCHMARK_TEMPLATE(benchloopTc5ModulusScalar, int32_t)

--- a/MicroBenchmarks/LoopVectorization/SmallLoopTripCount.cpp
+++ b/MicroBenchmarks/LoopVectorization/SmallLoopTripCount.cpp
@@ -97,6 +97,40 @@ NOINLINE void loopTc3SelectionScalar(const Ty *__restrict A, Ty *__restrict B) {
 }
 
 template <typename Ty>
+NOINLINE void loopTc5SelectionVector(const Ty *__restrict A, Ty *__restrict B) {
+  LOOP_VECTORIZE_ENABLE
+  for (int i = 0; i < 5; i++) {
+    B[i] = B[i] < A[i] ? B[i] : A[i];
+  }
+}
+
+template <typename Ty>
+NOINLINE void loopTc5SelectionScalar(const Ty *__restrict A, Ty *__restrict B) {
+  LOOP_VECTORIZE_DISABLE
+  for (int i = 0; i < 5; i++) {
+    B[i] = B[i] < A[i] ? B[i] : A[i];
+  }
+}
+
+template <typename Ty>
+NOINLINE void loopTc3BitwiseXOrVector(const Ty *__restrict A,
+                                      Ty *__restrict B) {
+  LOOP_VECTORIZE_ENABLE
+  for (int i = 0; i < 3; i++) {
+    B[i] ^= A[i];
+  }
+}
+
+template <typename Ty>
+NOINLINE void loopTc3BitwiseXOrScalar(const Ty *__restrict A,
+                                      Ty *__restrict B) {
+  LOOP_VECTORIZE_DISABLE
+  for (int i = 0; i < 3; i++) {
+    B[i] ^= A[i];
+  }
+}
+
+template <typename Ty>
 NOINLINE void loopTc5BitwiseXOrVector(const Ty *__restrict A,
                                       Ty *__restrict B) {
   LOOP_VECTORIZE_ENABLE
@@ -201,6 +235,26 @@ void benchloopTc3SelectionScalar(benchmark::State &State) {
 }
 
 template <typename Ty>
+void benchloopTc5SelectionVector(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc5SelectionVector<Ty>);
+}
+
+template <typename Ty>
+void benchloopTc5SelectionScalar(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc5SelectionScalar<Ty>);
+}
+
+template <typename Ty>
+void benchloopTC3BitwiseXOrVector(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc3BitwiseXOrVector<Ty>);
+}
+
+template <typename Ty>
+void benchloopTC3BitwiseXOrScalar(benchmark::State &State) {
+  runBenchForSmallLoopTripCount<Ty>(State, loopTc3BitwiseXOrScalar<Ty>);
+}
+
+template <typename Ty>
 void benchloopTC5BitwiseXOrVector(benchmark::State &State) {
   runBenchForSmallLoopTripCount<Ty>(State, loopTc5BitwiseXOrVector<Ty>);
 }
@@ -251,6 +305,22 @@ BENCHMARK_TEMPLATE(benchloopTc3SelectionVector, int16_t)
     ->Name("tc3Selection/i16/vector");
 BENCHMARK_TEMPLATE(benchloopTc3SelectionScalar, int16_t)
     ->Name("tc3Selection/i16/scalar");
+BENCHMARK_TEMPLATE(benchloopTc5SelectionVector, int8_t)
+    ->Name("tc5Selection/i8/vector");
+BENCHMARK_TEMPLATE(benchloopTc5SelectionScalar, int8_t)
+    ->Name("tc5Selection/i8/scalar");
+BENCHMARK_TEMPLATE(benchloopTc5SelectionVector, int16_t)
+    ->Name("tc5Selection/i16/vector");
+BENCHMARK_TEMPLATE(benchloopTc5SelectionScalar, int16_t)
+    ->Name("tc5Selection/i16/scalar");
+BENCHMARK_TEMPLATE(benchloopTC3BitwiseXOrVector, int8_t)
+    ->Name("tc3BitwideXor/i8/vector");
+BENCHMARK_TEMPLATE(benchloopTC3BitwiseXOrScalar, int8_t)
+    ->Name("tc3BitwideXor/i8/scalar");
+BENCHMARK_TEMPLATE(benchloopTC3BitwiseXOrVector, int16_t)
+    ->Name("tc3BitwideXor/i16/vector");
+BENCHMARK_TEMPLATE(benchloopTC3BitwiseXOrScalar, int16_t)
+    ->Name("tc3BitwideXor/i16/scalar");
 BENCHMARK_TEMPLATE(benchloopTC5BitwiseXOrVector, int8_t)
     ->Name("tc5BitwideXor/i8/vector");
 BENCHMARK_TEMPLATE(benchloopTC5BitwiseXOrScalar, int8_t)


### PR DESCRIPTION
For targets where getMinTripCountTailFoldingThreshold returns a value greater than zero, https://github.com/llvm/llvm-project/pull/195823 has enabled better vectorization of loops where applicable. This micro benchmark is intended to show the impact of these changes on the relevant targets.

For targets where getMinTripCountTailFoldingThreshold returns zero, there will be no effect to runtime when comparing scalar vs vector.

Assisted-by: Codex