### PR TITLE
[AIX] Add compile-time max RSS reporting support on AIX.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,8 +324,9 @@ add_subdirectory(litsupport)
 option(TEST_SUITE_REPORT_COMPILE_MAX_RSS
        "Report max RSS for compile/link time (Apple/Linux only)" OFF)
 
-if (TEST_SUITE_REPORT_COMPILE_MAX_RSS AND NOT (APPLE OR CMAKE_SYSTEM_NAME STREQUAL "Linux"))
-  message(WARNING "TEST_SUITE_REPORT_COMPILE_MAX_RSS is only supported on Apple/Linux, ignored on this platform")
+if (TEST_SUITE_REPORT_COMPILE_MAX_RSS AND NOT (APPLE OR CMAKE_SYSTEM_NAME STREQUAL "Linux"
+                                                     OR CMAKE_SYSTEM_NAME STREQUAL "AIX"))
+  message(WARNING "TEST_SUITE_REPORT_COMPILE_MAX_RSS is only supported on Apple/Linux/AIX, ignored on this platform")
 endif()
 
 option(TEST_SUITE_COLLECT_COMPILE_TIME

--- a/tools/timeit.c
+++ b/tools/timeit.c
@@ -296,7 +296,7 @@ static int monitor_child_process(double start_time) {
   /* Apple reports max RSS in bytes */
   maxrss_bytes = (unsigned long) usage.ru_maxrss;
 #elif defined(__linux__) || defined(_AIX)
-  /* Linux reports max RSS in KiB */
+  /* Linux and AIX report max RSS in KiB */
   maxrss_bytes = (unsigned long) usage.ru_maxrss * 1024;
 #endif
 

--- a/tools/timeit.c
+++ b/tools/timeit.c
@@ -295,7 +295,7 @@ static int monitor_child_process(double start_time) {
 #if defined(__APPLE__)
   /* Apple reports max RSS in bytes */
   maxrss_bytes = (unsigned long) usage.ru_maxrss;
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(_AIX)
   /* Linux reports max RSS in KiB */
   maxrss_bytes = (unsigned long) usage.ru_maxrss * 1024;
 #endif
@@ -404,7 +404,7 @@ static int monitor_child_process(double start_time) {
               real_time, user_time, sys_time);
     } else {
       if (g_report_maxrss)
-#if defined(__APPLE__) || defined(__linux__)
+#if defined(__APPLE__) || defined(__linux__) || defined(_AIX)
         fprintf(stderr, "%12.4f real %12.4f user %12.4f sys %12lu maxrss\n",
                 real_time, user_time, sys_time, maxrss_bytes);
 #else
@@ -428,7 +428,7 @@ static int monitor_child_process(double start_time) {
     fprintf(fp, "%-10s %.4f\n", "real", real_time);
     fprintf(fp, "%-10s %.4f\n", "user", user_time);
     fprintf(fp, "%-10s %.4f\n", "sys", sys_time);
-#if defined(__APPLE__) || defined(__linux__)
+#if defined(__APPLE__) || defined(__linux__) || defined(_AIX)
     if (g_report_maxrss)
       fprintf(fp, "%-10s %lu\n", "maxrss", maxrss_bytes);
 #endif


### PR DESCRIPTION
This is a follow-up of PR #373. It adds compile-time max RSS reporting support on AIX.