### PR TITLE
[MicroBenchmarks] Add missing `<cstdlib>` include

### DIFF
--- a/MicroBenchmarks/LoopVectorization/main.cpp
+++ b/MicroBenchmarks/LoopVectorization/main.cpp
@@ -1,3 +1,5 @@
+#include <cstdlib>
+
 #include "benchmark/benchmark.h"
 
 int main(int argc, char *argv[]) {

--- a/MicroBenchmarks/SLPVectorization/main.cpp
+++ b/MicroBenchmarks/SLPVectorization/main.cpp
@@ -1,3 +1,5 @@
+#include <cstdlib>
+
 #include "benchmark/benchmark.h"
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
The `EXIT_SUCCESS` identifier is defined in `<cstdlib>`

See buildbot failure started occurring after libc++ has dropped transitive includes in https://github.com/llvm/llvm-project/pull/195509:

https://lab.llvm.org/buildbot/#/builders/229/builds/1990/steps/12/logs/stdio