### PR TITLE
[gfortran] Disable metadirective-8 test

### DIFF
--- a/Fortran/gfortran/regression/gomp/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/gomp/DisabledFiles.cmake
@@ -419,6 +419,9 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   reduction3.f90
   sharing-3.f90
   linear-5.f90 # Re-enable this test when default OpenMP version = 5.2
+  # This test should not be expected to fail now that metadirective lowering
+  # is implemented.
+  metadirective-8.f90
 
   # These tests fail, but the cause of their failure needs to be investigated.
   allocate-10.f90


### PR DESCRIPTION
It is marked as XFAIL but now that metadirective lowering was
implemented it passes. This broke several buildbots, so this PR disables
metadirective-8 test for now.
After syncing the gfortran tests and removing XFAIL this test should be
re-enabled.
