### PR TITLE
[flang][OpenMP] Update test expectation for collapse on imperfectly nested loop

### DIFF
--- a/Fortran/gfortran/regression/gomp/tests.cmake
+++ b/Fortran/gfortran/regression/gomp/tests.cmake
@@ -226,7 +226,7 @@ compile;if-1.f90;;;;
 compile;imperfect-gotos.f90;xfail;;;
 compile;imperfect-invalid-scope.f90;xfail;;;
 compile;imperfect1.f90;xfail;;;
-compile;imperfect2.f90;xfail;;;
+compile;imperfect2.f90;;;;
 compile;imperfect3.f90;xfail;;;
 compile;imperfect4.f90;xfail;;;
 compile;imperfect5.f90;xfail;;;


### PR DESCRIPTION
Collapse is now implemented for imperfectly nested loops. This change is for https://github.com/llvm/llvm-project/pull/202435 and should not be merged until that PR is approved and merged.

Relates to issue: https://github.com/llvm/llvm-project/issues/199092