### PR TITLE
[HIP] Enable multi-version catch tests

### DIFF
--- a/External/HIP/CMakeLists.txt
+++ b/External/HIP/CMakeLists.txt
@@ -7,7 +7,16 @@ message(STATUS "TEST_SUITE_HIP_ROOT: ${TEST_SUITE_HIP_ROOT}")
 get_filename_component(HIP_CLANG_PATH ${CMAKE_CXX_COMPILER} DIRECTORY)
 message(STATUS "HIP_CLANG_PATH: ${HIP_CLANG_PATH}")
 
+# Options for enabling tests for external projects (Kokkos, Ginkgo, rocPRIM)
+option(EXTERNAL_HIP_TESTS_KOKKOS "Download, build, and test Kokkos HIP backend" OFF)
+option(EXTERNAL_HIP_TESTS_GINKGO "Download, build, and test Ginkgo HIP backend" OFF)
+option(EXTERNAL_HIP_TESTS_ROCPRIM "Download, build, and test rocPRIM" OFF)
+
+# Options to enable / disable specific test categories
+option(HIP_ENABLE_BLENDER_TEST "Enable Blender ray-tracing test (requires Blender 3.4+ and Python dependencies)" OFF)
+
 # Include Catch tests integration module
+include(${CMAKE_CURRENT_LIST_DIR}/HipCatchTests.cmake)
 
 # Find Python interpreter for running llvm-lit
 # The llvm-lit script may have a hardcoded Python version in its shebang
@@ -24,7 +33,6 @@ else()
   set(HIP_TEST_SUITE_LIT_BINARY ${TEST_SUITE_LIT})
   message(WARNING "Python3 not found, HIP tests may fail if llvm-lit has wrong shebang")
 endif()
-include(${CMAKE_CURRENT_LIST_DIR}/HipCatchTests.cmake)
 
 # Get rocm-libraries commit from TheRock (for version alignment)
 function(get_therock_rocm_libraries_version OUT_VAR)

--- a/External/HIP/CMakeLists.txt
+++ b/External/HIP/CMakeLists.txt
@@ -13,7 +13,7 @@ option(EXTERNAL_HIP_TESTS_GINKGO "Download, build, and test Ginkgo HIP backend" 
 option(EXTERNAL_HIP_TESTS_ROCPRIM "Download, build, and test rocPRIM" OFF)
 
 # Options to enable / disable specific test categories
-option(HIP_ENABLE_BLENDER_TEST "Enable Blender ray-tracing test (requires Blender 3.4+ and Python dependencies)" OFF)
+option(HIP_ENABLE_BLENDER_TEST "Enable Blender ray-tracing test (requires Blender 3.4+ and Python dependencies)" ON)
 
 # Include Catch tests integration module
 include(${CMAKE_CURRENT_LIST_DIR}/HipCatchTests.cmake)

--- a/External/HIP/CMakeLists.txt
+++ b/External/HIP/CMakeLists.txt
@@ -97,7 +97,7 @@ macro(create_one_hipify_cuda_test TestName TestSource VairantOffload VariantSuff
   add_custom_command(OUTPUT ${_hip_src}
                      COMMAND ${HIPIFY_EXE} "${_cuda_src}" -o "${_hip_src}"
                      DEPENDS "${_cuda_src}")
-  add_custom_target(${_hipify_target} DEPENDS ${_hip_src})
+  add_custom_target(${_hipify_target}-${VariantSuffix} DEPENDS ${_hip_src})
 
   set(_executable ${TestName}-${VariantSuffix})
   set(_executable_path ${CMAKE_CURRENT_BINARY_DIR}/${_executable})
@@ -125,7 +125,7 @@ macro(create_one_hipify_cuda_test TestName TestSource VairantOffload VariantSuff
   # For the HIP case, we set a huge number and assume that the latest C++
   # standard version is supported by the library.
   target_compile_definitions(${_executable} PRIVATE STDLIB_VERSION=9999)
-  add_dependencies(${_executable} ${_hipify_target})
+  add_dependencies(${_executable} ${_hipify_target}-${VariantSuffix})
   if(VariantLibs)
     target_link_libraries(${_executable} ${VariantLibs})
   endif()
@@ -198,16 +198,18 @@ macro(create_local_hip_tests VariantSuffix)
       message(WARNING "hipify-perl not found for ROCm installation in ${_RocmPath}.")
   endif()
 
-  # Add test for Blender.
-  configure_file(workload/blender/test_blender.sh.in ${CMAKE_CURRENT_BINARY_DIR}/test_blender.sh @ONLY)
-  configure_file(workload/blender/verify_blender.sh.in ${CMAKE_CURRENT_BINARY_DIR}/verify_blender.sh @ONLY)
-  file(COPY utils/log_data.py DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
-  file(COPY utils/compare_image.py DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
-  file(COPY utils/requirements.txt DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
-  llvm_test_run(EXECUTABLE "/bin/bash" "test_blender.sh")
-  llvm_test_verify(/bin/bash verify_blender.sh %o)
-  llvm_add_test(blender.test test_blender.sh)
-  list(APPEND VARIANT_SIMPLE_TEST_TARGETS blender.test)
+  if (HIP_ENABLE_BLENDER_TEST)
+    # Add test for Blender.
+    configure_file(workload/blender/test_blender.sh.in ${CMAKE_CURRENT_BINARY_DIR}/test_blender.sh @ONLY)
+    configure_file(workload/blender/verify_blender.sh.in ${CMAKE_CURRENT_BINARY_DIR}/verify_blender.sh @ONLY)
+    file(COPY utils/log_data.py DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+    file(COPY utils/compare_image.py DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+    file(COPY utils/requirements.txt DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+    llvm_test_run(EXECUTABLE "/bin/bash" "test_blender.sh")
+    llvm_test_verify(/bin/bash verify_blender.sh %o)
+    llvm_add_test(blender.test test_blender.sh)
+    list(APPEND VARIANT_SIMPLE_TEST_TARGETS blender.test)
+  endif()
 endmacro()
 
 function(create_hip_test VariantSuffix)

--- a/External/HIP/HipCatchTests.cmake
+++ b/External/HIP/HipCatchTests.cmake
@@ -256,7 +256,7 @@ function(create_generic_target_executables TEST_BASENAME TEST_DIR VARIANT_SUFFIX
   set(_output_path_regular "${_output_dir}/${_exe_name_regular}")
 
   add_custom_command(
-    OUTPUT "${_output_path_regular}"
+    OUTPUT "${_output_path_regular}-${VARIANT_SUFFIX}"
     COMMAND ${CMAKE_COMMAND} -E make_directory "${_output_dir}"
     COMMAND ${CMAKE_CXX_COMPILER}
       -DNO_GENERIC_TARGET_ONLY_TEST
@@ -265,7 +265,7 @@ function(create_generic_target_executables TEST_BASENAME TEST_DIR VARIANT_SUFFIX
       -w
       ${HIP_GENERIC_TARGET_ARCHS}
       ${_common_sources}
-      -o "${_output_path_regular}"
+      -o "${_output_path_regular}-${VARIANT_SUFFIX}"
       --hip-path=${ROCM_PATH}
       --rocm-path=${ROCM_PATH}
       --hip-link
@@ -285,7 +285,7 @@ function(create_generic_target_executables TEST_BASENAME TEST_DIR VARIANT_SUFFIX
   set(_output_path_compressed "${_output_dir}/${_exe_name_compressed}")
 
   add_custom_command(
-    OUTPUT "${_output_path_compressed}"
+    OUTPUT "${_output_path_compressed}-${VARIANT_SUFFIX}"
     COMMAND ${CMAKE_COMMAND} -E make_directory "${_output_dir}"
     COMMAND ${CMAKE_CXX_COMPILER}
       -DNO_GENERIC_TARGET_ONLY_TEST
@@ -296,7 +296,7 @@ function(create_generic_target_executables TEST_BASENAME TEST_DIR VARIANT_SUFFIX
       -w
       ${HIP_GENERIC_TARGET_ARCHS}
       ${_common_sources}
-      -o "${_output_path_compressed}"
+      -o "${_output_path_compressed}-${VARIANT_SUFFIX}"
       --hip-path=${ROCM_PATH}
       --rocm-path=${ROCM_PATH}
       --hip-link
@@ -313,11 +313,11 @@ function(create_generic_target_executables TEST_BASENAME TEST_DIR VARIANT_SUFFIX
 
   # Create custom targets for these executables
   add_custom_target(hipSquareGenericTargetOnly-${VARIANT_SUFFIX}
-    DEPENDS "${_output_path_regular}"
+    DEPENDS "${_output_path_regular}-${VARIANT_SUFFIX}"
   )
 
   add_custom_target(hipSquareGenericTargetOnlyCompressed-${VARIANT_SUFFIX}
-    DEPENDS "${_output_path_compressed}"
+    DEPENDS "${_output_path_compressed}-${VARIANT_SUFFIX}"
   )
 
   # Make the main test executable depend on these


### PR DESCRIPTION
Address various places where -${VARIANT_SUFFIX} appears to have been missing. This is a problem when running in an environment with multiple different ROCm versions installed.