### PR TITLE
[MultiSource] Fix argument parsing bug when program path contains parameters as substring

### DIFF
--- a/MultiSource/Benchmarks/DOE-ProxyApps-C++/miniFE/param_utils.cpp
+++ b/MultiSource/Benchmarks/DOE-ProxyApps-C++/miniFE/param_utils.cpp
@@ -35,7 +35,8 @@ namespace Mantevo {
 //-------------------------------------------------------------
 void read_args_into_string(int argc, char** argv, std::string& arg_string)
 {
-  arg_string = argv[0];
+  // Fix argument parsing to exclude argv[0] and prevent false detection of parameters in program path.
+  arg_string = "";
   for(int i=1; i<argc; ++i) {
     arg_string += " " + std::string(argv[i]);
   }

--- a/MultiSource/Benchmarks/DOE-ProxyApps-C++/miniFE/param_utils.cpp
+++ b/MultiSource/Benchmarks/DOE-ProxyApps-C++/miniFE/param_utils.cpp
@@ -35,7 +35,7 @@ namespace Mantevo {
 //-------------------------------------------------------------
 void read_args_into_string(int argc, char** argv, std::string& arg_string)
 {
-  // Fix argument parsing to exclude argv[0] and prevent false detection of parameters in program path.
+  // Skip argv[0] since we're interested in program arguments only.
   arg_string = "";
   for(int i=1; i<argc; ++i) {
     arg_string += " " + std::string(argv[i]);


### PR DESCRIPTION
The `read_args_into_string()` function was incorrectly including `argv[0]` (the program path) in the argument string. This caused a bug where if the executable path contained consecutive "nx" characters (e.g., /openxl/minife), the argument parser would mistakenly interpret this as the `-nx` command-line parameter.

Fix was to change the initialization of `arg_string` from `argv[0] `to an empty string "". Now we only process actual CLI arguments starting from argv[1], excluding the program path entirely.

```
./miniFE -nx 64 -ny 64 -nz 64
Final Resid Norm: 4.15881e-15

# with nx in the path
/openxlc/miniFE -nx 64 -ny 64 -nz 64
Final Resid Norm: 2.6077e-14
```