### PR TITLE
Add temporary work-around to ABI-Testsuite to keep it running until we can update it to use the lit internal shell.

### DIFF
--- a/ABI-Testsuite/test/lit.site.cfg
+++ b/ABI-Testsuite/test/lit.site.cfg
@@ -14,7 +14,8 @@ config.name = "SN C++ IA64 ABI Tests"
 #
 # For now we require '&&' between commands, until they get globally killed and
 # the test runner updated.
-config.test_format = lit.formats.ShTest(execute_external=True)
+config.test_format = lit.formats.ShTest(execute_external=True,
+                                        force_execute_external=True)
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [".c", ".cpp"]


### PR DESCRIPTION
We have not yet updated the test suite to make sure it works with the lit internal shell, but now that it is giving an error, it is causing our buildbot to fail (https://lab.llvm.org/buildbot/#/builders/8/builds/31577). This work-around lets it continue to run until we can update the test to make sure it works correctly with the lit internal shell.