### PR TITLE
[gfortran] Disable test incorrectly using assumed-size array

### DIFF
--- a/Fortran/gfortran/regression/gomp/DisabledFiles.cmake
+++ b/Fortran/gfortran/regression/gomp/DisabledFiles.cmake
@@ -337,6 +337,9 @@ file(GLOB FAILING_FILES CONFIGURE_DEPENDS
   # Must be a constant value
   target2.f90
 
+  # Assumed-size arrays cannot be arguments to DEPEND clause
+  pr80918.f90
+
   # bad character ('{') in Fortran token
   declare-variant-10.f90
   declare-variant-11.f90


### PR DESCRIPTION
This testcase declares an assumed-size dummy array and passes it to the DEPEND clause, expecting successful compilation. This is not allowed in OpenMP and fails to compile with flang.