### PR TITLE
Switch ABI Test Suite to use the lit internal shell

### DIFF
--- a/ABI-Testsuite/test/lit.site.cfg
+++ b/ABI-Testsuite/test/lit.site.cfg
@@ -14,8 +14,7 @@ config.name = "SN C++ IA64 ABI Tests"
 #
 # For now we require '&&' between commands, until they get globally killed and
 # the test runner updated.
-config.test_format = lit.formats.ShTest(execute_external=True,
-                                        force_execute_external=True)
+config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [".c", ".cpp"]


### PR DESCRIPTION
I tested using the internal shell on our bot and it seemed to work, so I'm going to enable it and see if our bot breaks.