### PR TITLE
[HIP] Add test with s_bitreplicate

### DIFF
--- a/External/HIP/CMakeLists.txt
+++ b/External/HIP/CMakeLists.txt
@@ -140,6 +140,9 @@ macro(create_local_hip_tests VariantSuffix)
   # Set per-source compilation/link options
   set_source_files_properties(with-fopenmp.hip PROPERTIES
     COMPILE_FLAGS -fopenmp)
+  # Use GlobalISel for device compilation
+  set_source_files_properties(s-bitreplicate.hip PROPERTIES
+    COMPILE_FLAGS "-fno-offload-lto -Xarch_device -fglobal-isel")
   # TODO: Add the flag after the kernel argument splitting pass is enabled.
   #set_source_files_properties(split-kernel-args.hip PROPERTIES
   #  COMPILE_FLAGS "-mllvm -amdgpu-enable-split-kernel-args")
@@ -156,6 +159,7 @@ macro(create_local_hip_tests VariantSuffix)
   list(APPEND HIP_LOCAL_TESTS fast-i24-div-path)
   list(APPEND HIP_LOCAL_TESTS udivrem23)
   list(APPEND HIP_LOCAL_TESTS udivrem24)
+  list(APPEND HIP_LOCAL_TESTS s-bitreplicate)
 
   list(APPEND HIP_LOCAL_TESTS InOneWeekend)
   list(APPEND HIP_LOCAL_TESTS TheNextWeek)

--- a/External/HIP/CMakeLists.txt
+++ b/External/HIP/CMakeLists.txt
@@ -140,10 +140,6 @@ macro(create_local_hip_tests VariantSuffix)
   # Set per-source compilation/link options
   set_source_files_properties(with-fopenmp.hip PROPERTIES
     COMPILE_FLAGS -fopenmp)
-  # FIXME: Ideally GlobalISel should be enabled for the whole HIP suite and not
-  # just s-bitreplicate test.
-  set_source_files_properties(s-bitreplicate.hip PROPERTIES
-    COMPILE_FLAGS "-fno-offload-lto -Xarch_device -fglobal-isel")
   # TODO: Add the flag after the kernel argument splitting pass is enabled.
   #set_source_files_properties(split-kernel-args.hip PROPERTIES
   #  COMPILE_FLAGS "-mllvm -amdgpu-enable-split-kernel-args")

--- a/External/HIP/CMakeLists.txt
+++ b/External/HIP/CMakeLists.txt
@@ -140,7 +140,8 @@ macro(create_local_hip_tests VariantSuffix)
   # Set per-source compilation/link options
   set_source_files_properties(with-fopenmp.hip PROPERTIES
     COMPILE_FLAGS -fopenmp)
-  # Use GlobalISel for device compilation
+  # FIXME: Ideally GlobalISel should be enabled for the whole HIP suite and not
+  # just s-bitreplicate test.
   set_source_files_properties(s-bitreplicate.hip PROPERTIES
     COMPILE_FLAGS "-fno-offload-lto -Xarch_device -fglobal-isel")
   # TODO: Add the flag after the kernel argument splitting pass is enabled.

--- a/External/HIP/s-bitreplicate.hip
+++ b/External/HIP/s-bitreplicate.hip
@@ -1,0 +1,70 @@
+#include <hip/hip_runtime.h>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+// Execution test for the divergent lowering of s_bitreplicate (bit i -> bits
+// 2i, 2i+1), which can be expanded on VALU via perm and shifts.
+
+#define HIP_CHECK(call)                                                        \
+  do {                                                                         \
+    hipError_t err = (call);                                                   \
+    if (err != hipSuccess) {                                                   \
+      printf("HIP error: %s at %s:%d\n", hipGetErrorString(err), __FILE__,     \
+             __LINE__);                                                        \
+      std::exit(EXIT_FAILURE);                                                 \
+    }                                                                          \
+  } while (0)
+
+__global__ void bitreplicate_kernel(uint64_t *out, int n) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    // Divergent input: differs between lanes within a wave.
+    uint32_t v = idx * 2654435761u + 13u;
+    out[idx] = __builtin_amdgcn_s_bitreplicate(v);
+  }
+}
+
+static uint64_t reference_bitreplicate(uint32_t x) {
+  uint64_t r = 0;
+  for (int i = 0; i < 32; ++i)
+    if (x & (1u << i))
+      r |= (uint64_t)0x3 << (2 * i);
+  return r;
+}
+
+int main() {
+  const int N = 4096;
+  const size_t bytes = N * sizeof(uint64_t);
+
+  uint64_t *d_out;
+  HIP_CHECK(hipMalloc((void **)&d_out, bytes));
+
+  const int threads = 256;
+  bitreplicate_kernel<<<(N + threads - 1) / threads, threads>>>(d_out, N);
+  HIP_CHECK(hipDeviceSynchronize());
+
+  uint64_t *h_out = (uint64_t *)malloc(bytes);
+  HIP_CHECK(hipMemcpy(h_out, d_out, bytes, hipMemcpyDeviceToHost));
+
+  int errors = 0;
+  for (int i = 0; i < N; ++i) {
+    uint32_t v = (uint32_t)i * 2654435761u + 13u;
+    uint64_t expected = reference_bitreplicate(v);
+    if (h_out[i] != expected) {
+      if (errors < 8)
+        printf("error i=%d in=0x%08x got=0x%016llx exp=0x%016llx\n", i, v,
+               (unsigned long long)h_out[i], (unsigned long long)expected);
+      ++errors;
+    }
+  }
+
+  if (errors != 0)
+    printf("%d errors\n", errors);
+  else
+    printf("PASSED!\n");
+
+  free(h_out);
+  HIP_CHECK(hipFree(d_out));
+  return errors;
+}

--- a/External/HIP/s-bitreplicate.hip
+++ b/External/HIP/s-bitreplicate.hip
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <memory>
 
 // Execution test for the divergent lowering of s_bitreplicate (bit i -> bits
 // 2i, 2i+1), which can be expanded on VALU via perm and shifts.
@@ -37,15 +38,15 @@ int main() {
   const int N = 4096;
   const size_t bytes = N * sizeof(uint64_t);
 
-  uint64_t *d_out;
+  uint64_t *d_out = nullptr;
   HIP_CHECK(hipMalloc((void **)&d_out, bytes));
 
   const int threads = 256;
   bitreplicate_kernel<<<(N + threads - 1) / threads, threads>>>(d_out, N);
   HIP_CHECK(hipDeviceSynchronize());
 
-  uint64_t *h_out = (uint64_t *)malloc(bytes);
-  HIP_CHECK(hipMemcpy(h_out, d_out, bytes, hipMemcpyDeviceToHost));
+  auto h_out = std::make_unique<uint64_t[]>(N);
+  HIP_CHECK(hipMemcpy(h_out.get(), d_out, bytes, hipMemcpyDeviceToHost));
 
   int errors = 0;
   for (int i = 0; i < N; ++i) {
@@ -64,7 +65,6 @@ int main() {
   else
     printf("PASSED!\n");
 
-  free(h_out);
   HIP_CHECK(hipFree(d_out));
   return errors;
 }

--- a/External/HIP/s-bitreplicate.reference_output
+++ b/External/HIP/s-bitreplicate.reference_output
@@ -1,0 +1,2 @@
+PASSED!
+exit 0


### PR DESCRIPTION
Add a test for s_bitreplicate when the inputs are non-uniform. The intrinsic is expanded to a VALU sequence.

Needs https://github.com/llvm/llvm-project/pull/208308.