### PR TITLE
[compare.py] Add flag for outputting in markdown and csv format

### DIFF
--- a/utils/compare.py
+++ b/utils/compare.py
@@ -26,8 +26,7 @@ def read_lit_json(filename):
     info_columns = ["hash"]
     # Pass1: Figure out metrics (= the column index)
     if "tests" not in jsondata:
-        print("%s: Could not find toplevel 'tests' key" % filename,
-              file=sys.stderr)
+        print("%s: Could not find toplevel 'tests' key" % filename, file=sys.stderr)
         sys.exit(1)
     for test in jsondata["tests"]:
         name = test.get("name")
@@ -38,8 +37,10 @@ def read_lit_json(filename):
             sys.stderr.write("Error: Multiple tests with name '%s'\n" % name)
             sys.exit(1)
         if "metrics" not in test:
-            print("Warning: '%s' has no metrics, skipping!" % test["name"],
-                  file=sys.stderr)
+            print(
+                "Warning: '%s' has no metrics, skipping!" % test["name"],
+                file=sys.stderr,
+            )
             continue
         names.add(name)
         for name in test["metrics"].keys():
@@ -518,8 +519,7 @@ def print_result(
             print(out)
 
         # Print a summary pivoted by metric
-        d_summary = d.drop(columns=exclude_from_summary, level=1,
-                           errors='ignore')
+        d_summary = d.drop(columns=exclude_from_summary, level=1, errors="ignore")
         print(d_summary.describe())
 
 

--- a/utils/compare.py
+++ b/utils/compare.py
@@ -658,8 +658,9 @@ def main():
     )
     parser.add_argument(
         "--format",
-        choices=['csv', 'md'],
-        help="Output results in a specific format. Requires the tabulate pacakge.",
+        choices=["text", "csv", "md"],
+        default="text",
+        help="Output results in a specific format. csv and md require the tabulate package.",
     )
     config = parser.parse_args()
 

--- a/utils/compare.py
+++ b/utils/compare.py
@@ -26,7 +26,8 @@ def read_lit_json(filename):
     info_columns = ["hash"]
     # Pass1: Figure out metrics (= the column index)
     if "tests" not in jsondata:
-        print("%s: Could not find toplevel 'tests' key")
+        print("%s: Could not find toplevel 'tests' key" % filename,
+              file=sys.stderr)
         sys.exit(1)
     for test in jsondata["tests"]:
         name = test.get("name")
@@ -37,7 +38,8 @@ def read_lit_json(filename):
             sys.stderr.write("Error: Multiple tests with name '%s'\n" % name)
             sys.exit(1)
         if "metrics" not in test:
-            print("Warning: '%s' has no metrics, skipping!" % test["name"])
+            print("Warning: '%s' has no metrics, skipping!" % test["name"],
+                  file=sys.stderr)
             continue
         names.add(name)
         for name in test["metrics"].keys():
@@ -319,7 +321,7 @@ def print_filter_stats(reason, before, after):
     n_after = len(after.groupby(level=1))
     n_filtered = n_before - n_after
     if n_filtered != 0:
-        print("%s: %s (filtered out)" % (reason, n_filtered))
+        print("%s: %s (filtered out)" % (reason, n_filtered), file=sys.stderr)
 
 
 # Truncate a string to a maximum length by keeping a prefix, a suffix and ...
@@ -380,7 +382,8 @@ def print_result(
     absolute_diff=False,
     lhs_name="lhs",
     rhs_name="rhs",
-    only_significant=False
+    only_significant=False,
+    format=None,
 ):
     metrics = d.columns.levels[0]
     if sort_by_abs:
@@ -487,31 +490,37 @@ def print_result(
         'diff_ci_rel', 'diff_ci_abs',
     ]
 
-    # Print an empty value instead of NaN (for the geomean row).
-    if split_by_metric:
-        for m in metrics:
-            metric_data = dataout[["Program", m]]
-            out = metric_data.to_string(
+    if format == "md":
+        dataout.to_markdown(buf=sys.stdout, index=False)
+    elif format == "csv":
+        dataout.to_csv(sys.stdout, index=False)
+    else:
+        # Print an empty value instead of NaN (for the geomean row).
+        if split_by_metric:
+            for m in metrics:
+                metric_data = dataout[["Program", m]]
+                out = metric_data.to_string(
+                    index=False,
+                    justify="left",
+                    na_rep="",
+                    float_format=float_format,
+                    formatters=formatters,
+                )
+                print(f"{out}\n")
+        else:
+            out = dataout.to_string(
                 index=False,
                 justify="left",
                 na_rep="",
                 float_format=float_format,
                 formatters=formatters,
             )
-            print(f"{out}\n")
-    else:
-        out = dataout.to_string(
-            index=False,
-            justify="left",
-            na_rep="",
-            float_format=float_format,
-            formatters=formatters,
-        )
-        print(out)
+            print(out)
 
-    # Print a summary pivoted by metric
-    d_summary = d.drop(columns=exclude_from_summary, level=1, errors='ignore')
-    print(d_summary.describe())
+        # Print a summary pivoted by metric
+        d_summary = d.drop(columns=exclude_from_summary, level=1,
+                           errors='ignore')
+        print(d_summary.describe())
 
 
 def main():
@@ -647,6 +656,11 @@ def main():
         default=False,
         help="Show only results where a metric has changed"
     )
+    parser.add_argument(
+        "--format",
+        choices=['csv', 'md'],
+        help="Output results in a specific format. Requires the tabulate pacakge.",
+    )
     config = parser.parse_args()
 
     if config.show_diff is None:
@@ -730,7 +744,7 @@ def main():
     # Filter data
     proggroup = data.groupby(level=1)
     initial_size = len(proggroup.indices)
-    print("Tests: %s" % (initial_size,))
+    print("Tests: %s" % (initial_size,), file=sys.stderr)
     if config.filter_failed and hasattr(data, "Exec"):
         newdata = filter_failed(data)
         print_filter_stats("Failed", data, newdata)
@@ -760,10 +774,10 @@ def main():
         data = newdata
     final_size = len(data.groupby(level=1))
     if final_size != initial_size:
-        print("Remaining: %d" % (final_size,))
+        print("Remaining: %d" % (final_size,), file=sys.stderr)
 
     # Reduce / add columns
-    print("Metric: %s" % (",".join(metrics),))
+    print("Metric: %s" % (",".join(metrics),), file=sys.stderr)
     if len(metrics) > 0:
         data = data[metrics]
 
@@ -781,7 +795,7 @@ def main():
         sortkey = data.columns.levels[1][0]
 
     # Print data
-    print("")
+    print("", file=sys.stderr)
     shorten_names = not config.full
     limit_output = (not config.all) and (not config.full)
     print_result(
@@ -798,6 +812,7 @@ def main():
         config.lhs_name,
         config.rhs_name,
         config.only_significant,
+        config.format,
     )
 
 


### PR DESCRIPTION
In order to display the results of compare.py in a github comment from the /test-suite workflow, this patch adds a --format=md flag.

It's pretty easy to support other formats too so I've added in a csv formatter too, it's useful for creating graphs and charts etc.

Some of the other print calls were moved to stderr so it doesn't clobber the formatted output on stdout.

Here's an example table produced below from `/utils/compare.py foo.json vs bar.json -m size..text --only-changed  --minimal-names --lhs-name base --rhs-name head --format=md`:

| ('Program', '')    |   ('size..text', 'base') |   ('size..text', 'head') |   ('size..text', 'diff') |
|:-------------------|-------------------------:|-------------------------:|-------------------------:|
| queens             |                     1144 |                     1170 |              0.0227273   |
| fldry              |                      882 |                      902 |              0.0226757   |
| dry                |                      774 |                      788 |              0.0180879   |
| mst                |                     1850 |                     1876 |              0.0140541   |
| IRSmk              |                     5236 |                     5302 |              0.012605    |
| spiff              |                    15402 |                    15572 |              0.0110375   |
| power              |                     4544 |                     4592 |              0.0105634   |
| Shootout-sieve     |                      404 |                      408 |              0.00990099  |
| himenobmtxpa       |                     6356 |                     6412 |              0.00881057  |
| ray                |                     3226 |                     3254 |              0.00867948  |
| jacobi-2d          |                     2806 |                     2824 |              0.00641483  |
| richards_benchmark |                     2718 |                     2734 |              0.00588668  |
| sim                |                    11232 |                    11296 |              0.00569801  |
| syr2k              |                     2476 |                     2490 |              0.00565428  |
| HPCCG              |                    14598 |                    14676 |              0.0053432   |
| Geomean difference |                      nan |                      nan |              0.000118887 |

There's probably nicer ways to format the floats/geomean difference but I figured it would be good to just get the basics plugged in for now.