### PR TITLE
Fix telecomm-FFT and beamformer benchmarks on GCC

### DIFF
--- a/MultiSource/Benchmarks/MiBench/telecomm-FFT/fourierf.c
+++ b/MultiSource/Benchmarks/MiBench/telecomm-FFT/fourierf.c
@@ -168,6 +168,13 @@ void fft_float (
     }
 }
 
+// GCC doesn't support the FP_CONTRACT pragma.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC optimize ("fp-contract=off")
+#else
+#pragma STDC FP_CONTRACT OFF
+#endif
+
 void fft_float_StrictFP (
     unsigned  NumSamples,
     int       InverseTransform,
@@ -176,7 +183,6 @@ void fft_float_StrictFP (
     float    *RealOut,
     float    *ImagOut )
 {
-#pragma STDC FP_CONTRACT OFF
     unsigned NumBits;    /* Number of bits needed to store indices */
     unsigned i, j, k, n;
     unsigned BlockSize, BlockEnd;

--- a/MultiSource/Benchmarks/MiBench/telecomm-FFT/fourierf.c
+++ b/MultiSource/Benchmarks/MiBench/telecomm-FFT/fourierf.c
@@ -24,6 +24,13 @@
 #include "fourier.h"
 #include "ddcmath.h"
 
+// GCC doesn't support the FP_CONTRACT pragma.
+#if defined(__GNUC__) && !defined(__clang__)
+#define GCC_FP_CONTRACT_OFF __attribute__((optimize("fp-contract=off")))
+#else
+#define GCC_FP_CONTRACT_OFF
+#endif
+
 #define CHECKPOINTER(p)  CheckPointer(p,#p)
 
 const double SinPi4Result = 0x1.6a09e667f3bccp-1;
@@ -168,13 +175,7 @@ void fft_float (
     }
 }
 
-// GCC doesn't support the FP_CONTRACT pragma.
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC optimize ("fp-contract=off")
-#else
-#pragma STDC FP_CONTRACT OFF
-#endif
-
+GCC_FP_CONTRACT_OFF
 void fft_float_StrictFP (
     unsigned  NumSamples,
     int       InverseTransform,
@@ -183,6 +184,7 @@ void fft_float_StrictFP (
     float    *RealOut,
     float    *ImagOut )
 {
+#pragma STDC FP_CONTRACT OFF
     unsigned NumBits;    /* Number of bits needed to store indices */
     unsigned i, j, k, n;
     unsigned BlockSize, BlockEnd;

--- a/MultiSource/Benchmarks/VersaBench/beamformer/beamformer.c
+++ b/MultiSource/Benchmarks/VersaBench/beamformer/beamformer.c
@@ -35,6 +35,13 @@
 #include <unistd.h>
 #include <math.h>
 
+// GCC doesn't support the FP_CONTRACT pragma.
+#if defined(__GNUC__) && !defined(__clang__)
+#define GCC_FP_CONTRACT_OFF __attribute__((optimize("fp-contract=off")))
+#else
+#define GCC_FP_CONTRACT_OFF
+#endif
+
 /* 
 This implementation is derived from the StreamIt implementation,
 rather than from the PCA VSIPL-based implementation.  It is intended
@@ -432,15 +439,10 @@ void Detector(int beam, float *data, float *output)
   }
 }
 
-// GCC doesn't support the FP_CONTRACT pragma.
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC optimize ("fp-contract=off")
-#else
-#pragma STDC FP_CONTRACT OFF
-#endif
-
+GCC_FP_CONTRACT_OFF
 void begin_StrictFP(void)
 {
+#pragma STDC FP_CONTRACT OFF
   struct BeamFirData coarse_fir_data[NUM_CHANNELS];
   struct BeamFirData fine_fir_data[NUM_CHANNELS];
   struct BeamFirData mf_fir_data[NUM_BEAMS];
@@ -504,8 +506,10 @@ void begin_StrictFP(void)
     }
 }
 
+GCC_FP_CONTRACT_OFF
 void InputGenerate_StrictFP(int channel, float *inputs, int n)
 {
+#pragma STDC FP_CONTRACT OFF
   int i;
   for (i = 0; i < n; i++)
   {
@@ -531,8 +535,10 @@ void InputGenerate_StrictFP(int channel, float *inputs, int n)
   }
 }
 
+GCC_FP_CONTRACT_OFF
 void BeamFirSetup_StrictFP(struct BeamFirData *data, int n)
 {
+#pragma STDC FP_CONTRACT OFF
   int i, j;
 
   data->len = n;
@@ -559,10 +565,12 @@ void BeamFirSetup_StrictFP(struct BeamFirData *data, int n)
 #endif
 }
 
+GCC_FP_CONTRACT_OFF
 void BeamFirFilter_StrictFP(struct BeamFirData *data,
                             int input_length, int decimation_ratio,
                             float *in, float *out)
 {
+#pragma STDC FP_CONTRACT OFF
   /* Input must be exactly 2*decimation_ratio long; output must be
    * exactly 2 long. */
   float real_curr = 0;
@@ -606,8 +614,10 @@ void BeamFirFilter_StrictFP(struct BeamFirData *data,
   }
 }
 
+GCC_FP_CONTRACT_OFF
 void BeamFormWeights_StrictFP(int beam, float *weights)
 {
+#pragma STDC FP_CONTRACT OFF
   int i;
   for (i = 0; i < NUM_CHANNELS; i++)
   {
@@ -627,9 +637,11 @@ void BeamFormWeights_StrictFP(int beam, float *weights)
   }
 }
 
+GCC_FP_CONTRACT_OFF
 void BeamForm_StrictFP(int beam, const float *weights, const float *input,
                        float *output)
 {
+#pragma STDC FP_CONTRACT OFF
   /* 2*NUM_CHANNELS inputs and weights; 2 outputs. */
   float real_curr = 0;
   float imag_curr = 0;
@@ -643,16 +655,20 @@ void BeamForm_StrictFP(int beam, const float *weights, const float *input,
   output[1] = imag_curr;
 }
 
+GCC_FP_CONTRACT_OFF
 void Magnitude_StrictFP(float *in, float *out, int n)
 {
+#pragma STDC FP_CONTRACT OFF
   int i;
   /* Should be 2n inputs, n outputs. */
   for (i = 0; i < n; i++)
     out[i] = sqrt(in[2*i]*in[2*i] + in[2*i+1]*in[2*i+1]);
 }
 
+GCC_FP_CONTRACT_OFF
 void Detector_StrictFP(int beam, float *data, float *output)
 {
+#pragma STDC FP_CONTRACT OFF
   int sample;
   /* Should be exactly NUM_POST_DEC_2 samples. */
   for (sample = 0; sample < NUM_POST_DEC_2; sample++)

--- a/MultiSource/Benchmarks/VersaBench/beamformer/beamformer.c
+++ b/MultiSource/Benchmarks/VersaBench/beamformer/beamformer.c
@@ -432,9 +432,15 @@ void Detector(int beam, float *data, float *output)
   }
 }
 
+// GCC doesn't support the FP_CONTRACT pragma.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC optimize ("fp-contract=off")
+#else
+#pragma STDC FP_CONTRACT OFF
+#endif
+
 void begin_StrictFP(void)
 {
-#pragma STDC FP_CONTRACT OFF
   struct BeamFirData coarse_fir_data[NUM_CHANNELS];
   struct BeamFirData fine_fir_data[NUM_CHANNELS];
   struct BeamFirData mf_fir_data[NUM_BEAMS];
@@ -500,7 +506,6 @@ void begin_StrictFP(void)
 
 void InputGenerate_StrictFP(int channel, float *inputs, int n)
 {
-#pragma STDC FP_CONTRACT OFF
   int i;
   for (i = 0; i < n; i++)
   {
@@ -528,7 +533,6 @@ void InputGenerate_StrictFP(int channel, float *inputs, int n)
 
 void BeamFirSetup_StrictFP(struct BeamFirData *data, int n)
 {
-#pragma STDC FP_CONTRACT OFF
   int i, j;
 
   data->len = n;
@@ -559,7 +563,6 @@ void BeamFirFilter_StrictFP(struct BeamFirData *data,
                             int input_length, int decimation_ratio,
                             float *in, float *out)
 {
-#pragma STDC FP_CONTRACT OFF
   /* Input must be exactly 2*decimation_ratio long; output must be
    * exactly 2 long. */
   float real_curr = 0;
@@ -605,7 +608,6 @@ void BeamFirFilter_StrictFP(struct BeamFirData *data,
 
 void BeamFormWeights_StrictFP(int beam, float *weights)
 {
-#pragma STDC FP_CONTRACT OFF
   int i;
   for (i = 0; i < NUM_CHANNELS; i++)
   {
@@ -628,7 +630,6 @@ void BeamFormWeights_StrictFP(int beam, float *weights)
 void BeamForm_StrictFP(int beam, const float *weights, const float *input,
                        float *output)
 {
-#pragma STDC FP_CONTRACT OFF
   /* 2*NUM_CHANNELS inputs and weights; 2 outputs. */
   float real_curr = 0;
   float imag_curr = 0;
@@ -644,7 +645,6 @@ void BeamForm_StrictFP(int beam, const float *weights, const float *input,
 
 void Magnitude_StrictFP(float *in, float *out, int n)
 {
-#pragma STDC FP_CONTRACT OFF
   int i;
   /* Should be 2n inputs, n outputs. */
   for (i = 0; i < n; i++)
@@ -653,7 +653,6 @@ void Magnitude_StrictFP(float *in, float *out, int n)
 
 void Detector_StrictFP(int beam, float *data, float *output)
 {
-#pragma STDC FP_CONTRACT OFF
   int sample;
   /* Should be exactly NUM_POST_DEC_2 samples. */
   for (sample = 0; sample < NUM_POST_DEC_2; sample++)


### PR DESCRIPTION
These benchmarks use #pragma STDC FP_CONTRACT OFF, but this isn't supported in GCC: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=20785#c7

Instead use a gcc specific function pragma when the compiler is GCC. We still want to allow FP contraction in the main part of the test.

Claude was used to help diagnose the failure.
