### PR TITLE
Fix Polybench benchmarks using FP_CONTRACT pragma on GCC

### DIFF
--- a/SingleSource/Benchmarks/Polybench/datamining/correlation/correlation.c
+++ b/SingleSource/Benchmarks/Polybench/datamining/correlation/correlation.c
@@ -22,10 +22,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int m,
 		 int n,
@@ -42,9 +39,6 @@ void init_array (int m,
       data[i][j] = (DATA_TYPE)(i*j)/M + i;
 
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -134,10 +128,7 @@ void kernel_correlation(int m, int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static void
 kernel_correlation_StrictFP(int m, int n,
                             DATA_TYPE float_n,
@@ -197,9 +188,6 @@ kernel_correlation_StrictFP(int m, int n,
     }
   corr[_PB_M-1][_PB_M-1] = SCALAR_VAL(1.0);
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/datamining/correlation/correlation.c
+++ b/SingleSource/Benchmarks/Polybench/datamining/correlation/correlation.c
@@ -22,6 +22,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int m,
 		 int n,
@@ -38,6 +42,9 @@ void init_array (int m,
       data[i][j] = (DATA_TYPE)(i*j)/M + i;
 
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -127,6 +134,10 @@ void kernel_correlation(int m, int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static void
 kernel_correlation_StrictFP(int m, int n,
                             DATA_TYPE float_n,
@@ -186,6 +197,9 @@ kernel_correlation_StrictFP(int m, int n,
     }
   corr[_PB_M-1][_PB_M-1] = SCALAR_VAL(1.0);
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/datamining/covariance/covariance.c
+++ b/SingleSource/Benchmarks/Polybench/datamining/covariance/covariance.c
@@ -22,10 +22,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int m, int n,
 		 DATA_TYPE *float_n,
@@ -40,9 +37,6 @@ void init_array (int m, int n,
     for (j = 0; j < M; j++)
       data[i][j] = ((DATA_TYPE) i*j) / M;
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -105,10 +99,7 @@ void kernel_covariance(int m, int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static void
 kernel_covariance_StrictFP(int m, int n,
                            DATA_TYPE float_n,
@@ -144,9 +135,6 @@ kernel_covariance_StrictFP(int m, int n,
         cov[j][i] = cov[i][j];
       }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/datamining/covariance/covariance.c
+++ b/SingleSource/Benchmarks/Polybench/datamining/covariance/covariance.c
@@ -22,6 +22,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int m, int n,
 		 DATA_TYPE *float_n,
@@ -36,6 +40,9 @@ void init_array (int m, int n,
     for (j = 0; j < M; j++)
       data[i][j] = ((DATA_TYPE) i*j) / M;
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -98,6 +105,10 @@ void kernel_covariance(int m, int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static void
 kernel_covariance_StrictFP(int m, int n,
                            DATA_TYPE float_n,
@@ -133,6 +144,9 @@ kernel_covariance_StrictFP(int m, int n,
         cov[j][i] = cov[i][j];
       }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/blas/gemm/gemm.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/blas/gemm/gemm.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array(int ni, int nj, int nk,
 		DATA_TYPE *alpha,
@@ -56,9 +53,6 @@ void init_array(int ni, int nj, int nk,
     for (j = 0; j < nj; j++)
       B[i][j] = (DATA_TYPE) (i*(j+2) % nj) / nj;
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -115,10 +109,7 @@ void kernel_gemm(int ni, int nj, int nk,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void kernel_gemm_StrictFP(int ni, int nj, int nk,
                           DATA_TYPE alpha,
@@ -146,9 +137,6 @@ void kernel_gemm_StrictFP(int ni, int nj, int nk,
     }
   }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/blas/gemm/gemm.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/blas/gemm/gemm.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array(int ni, int nj, int nk,
 		DATA_TYPE *alpha,
@@ -52,6 +56,9 @@ void init_array(int ni, int nj, int nk,
     for (j = 0; j < nj; j++)
       B[i][j] = (DATA_TYPE) (i*(j+2) % nj) / nj;
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -108,6 +115,10 @@ void kernel_gemm(int ni, int nj, int nk,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void kernel_gemm_StrictFP(int ni, int nj, int nk,
                           DATA_TYPE alpha,
@@ -135,6 +146,9 @@ void kernel_gemm_StrictFP(int ni, int nj, int nk,
     }
   }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/blas/gemver/gemver.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/blas/gemver/gemver.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int n,
 		 DATA_TYPE *alpha,
@@ -69,9 +66,6 @@ void init_array (int n,
         A[i][j] = (DATA_TYPE) (i*j % n) / n;
     }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -135,10 +129,7 @@ void kernel_gemver(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void kernel_gemver_StrictFP(int n,
                             DATA_TYPE alpha,
@@ -171,9 +162,6 @@ void kernel_gemver_StrictFP(int n,
     for (j = 0; j < _PB_N; j++)
       w[i] = w[i] +  alpha * A[i][j] * x[j];
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/blas/gemver/gemver.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/blas/gemver/gemver.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int n,
 		 DATA_TYPE *alpha,
@@ -65,6 +69,9 @@ void init_array (int n,
         A[i][j] = (DATA_TYPE) (i*j % n) / n;
     }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -128,6 +135,10 @@ void kernel_gemver(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void kernel_gemver_StrictFP(int n,
                             DATA_TYPE alpha,
@@ -160,6 +171,9 @@ void kernel_gemver_StrictFP(int n,
     for (j = 0; j < _PB_N; j++)
       w[i] = w[i] +  alpha * A[i][j] * x[j];
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/blas/gesummv/gesummv.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/blas/gesummv/gesummv.c
@@ -22,6 +22,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array(int n,
 		DATA_TYPE *alpha,
@@ -44,6 +48,9 @@ void init_array(int n,
       }
     }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -97,6 +104,10 @@ void kernel_gesummv(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void kernel_gesummv_StrictFP(int n,
                              DATA_TYPE alpha,
@@ -122,6 +133,9 @@ void kernel_gesummv_StrictFP(int n,
       y[i] = alpha * tmp[i] + beta * y[i];
     }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/blas/gesummv/gesummv.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/blas/gesummv/gesummv.c
@@ -22,10 +22,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array(int n,
 		DATA_TYPE *alpha,
@@ -48,9 +45,6 @@ void init_array(int n,
       }
     }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -104,10 +98,7 @@ void kernel_gesummv(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void kernel_gesummv_StrictFP(int n,
                              DATA_TYPE alpha,
@@ -133,9 +124,6 @@ void kernel_gesummv_StrictFP(int n,
       y[i] = alpha * tmp[i] + beta * y[i];
     }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/blas/symm/symm.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/blas/symm/symm.c
@@ -22,6 +22,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array(int m, int n,
 		DATA_TYPE *alpha,
@@ -53,6 +57,9 @@ void init_array(int m, int n,
       A[i][j] = -999; //regions of arrays that should not be used
   }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -113,6 +120,10 @@ void kernel_symm(int m, int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void kernel_symm(int m, int n,
 		 DATA_TYPE alpha,
@@ -144,6 +155,9 @@ void kernel_symm(int m, int n,
         C[i][j] = beta * C[i][j] + alpha*B[i][j] * A[i][i] + alpha * temp2;
      }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/blas/symm/symm.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/blas/symm/symm.c
@@ -22,10 +22,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array(int m, int n,
 		DATA_TYPE *alpha,
@@ -57,9 +54,6 @@ void init_array(int m, int n,
       A[i][j] = -999; //regions of arrays that should not be used
   }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -120,10 +114,7 @@ void kernel_symm(int m, int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void kernel_symm(int m, int n,
 		 DATA_TYPE alpha,
@@ -155,9 +146,6 @@ void kernel_symm(int m, int n,
         C[i][j] = beta * C[i][j] + alpha*B[i][j] * A[i][i] + alpha * temp2;
      }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/blas/syr2k/syr2k.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/blas/syr2k/syr2k.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array(int n, int m,
 		DATA_TYPE *alpha,
@@ -56,9 +53,6 @@ void init_array(int n, int m,
 	    C[i][j] = (DATA_TYPE) ((i*j+3)%n) / m;
 	  }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -115,10 +109,7 @@ void kernel_syr2k(int n, int m,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static void
 kernel_syr2k_StrictFP(int n, int m,
                       DATA_TYPE alpha,
@@ -146,9 +137,6 @@ kernel_syr2k_StrictFP(int n, int m,
 	}
   }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/blas/syr2k/syr2k.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/blas/syr2k/syr2k.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array(int n, int m,
 		DATA_TYPE *alpha,
@@ -52,6 +56,9 @@ void init_array(int n, int m,
 	    C[i][j] = (DATA_TYPE) ((i*j+3)%n) / m;
 	  }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -108,6 +115,10 @@ void kernel_syr2k(int n, int m,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static void
 kernel_syr2k_StrictFP(int n, int m,
                       DATA_TYPE alpha,
@@ -135,6 +146,9 @@ kernel_syr2k_StrictFP(int n, int m,
 	}
   }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/blas/syrk/syrk.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/blas/syrk/syrk.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array(int n, int m,
 		DATA_TYPE *alpha,
@@ -48,6 +52,9 @@ void init_array(int n, int m,
 #endif
 	      C[i][j] = (DATA_TYPE) ((i*j+2)%m) / m;
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -102,6 +109,10 @@ void kernel_syrk(int n, int m,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void kernel_syrk_StrictFP(int n, int m,
                           DATA_TYPE alpha,
@@ -127,6 +138,9 @@ void kernel_syrk_StrictFP(int n, int m,
     }
   }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/blas/syrk/syrk.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/blas/syrk/syrk.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array(int n, int m,
 		DATA_TYPE *alpha,
@@ -52,9 +49,6 @@ void init_array(int n, int m,
 #endif
 	      C[i][j] = (DATA_TYPE) ((i*j+2)%m) / m;
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -109,10 +103,7 @@ void kernel_syrk(int n, int m,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void kernel_syrk_StrictFP(int n, int m,
                           DATA_TYPE alpha,
@@ -138,9 +129,6 @@ void kernel_syrk_StrictFP(int n, int m,
     }
   }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/blas/trmm/trmm.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/blas/trmm/trmm.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array(int m, int n,
 		DATA_TYPE *alpha,
@@ -54,9 +51,6 @@ void init_array(int m, int n,
     }
  }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -111,10 +105,7 @@ void kernel_trmm(int m, int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static void
 kernel_trmm_StrictFP(int m, int n,
                      DATA_TYPE alpha,
@@ -139,9 +130,6 @@ kernel_trmm_StrictFP(int m, int n,
         B[i][j] = alpha * B[i][j];
      }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/blas/trmm/trmm.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/blas/trmm/trmm.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array(int m, int n,
 		DATA_TYPE *alpha,
@@ -50,6 +54,9 @@ void init_array(int m, int n,
     }
  }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -104,6 +111,10 @@ void kernel_trmm(int m, int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static void
 kernel_trmm_StrictFP(int m, int n,
                      DATA_TYPE alpha,
@@ -128,6 +139,9 @@ kernel_trmm_StrictFP(int m, int n,
         B[i][j] = alpha * B[i][j];
      }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/2mm/2mm.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/2mm/2mm.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 void init_array(int ni, int nj, int nk, int nl,
 		DATA_TYPE *alpha,
 		DATA_TYPE *beta,
@@ -60,9 +57,6 @@ void init_array(int ni, int nj, int nk, int nl,
 #endif
         D[i][j] = (DATA_TYPE) (i*(j+2) % nk) / nk;
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -121,10 +115,7 @@ void kernel_2mm(int ni, int nj, int nk, int nl,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static void
 kernel_2mm_StrictFP(int ni, int nj, int nk, int nl,
                          DATA_TYPE alpha,
@@ -154,9 +145,6 @@ kernel_2mm_StrictFP(int ni, int nj, int nk, int nl,
 	  D[i][j] += tmp[i][k] * C[k][j];
       }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/2mm/2mm.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/2mm/2mm.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 void init_array(int ni, int nj, int nk, int nl,
 		DATA_TYPE *alpha,
 		DATA_TYPE *beta,
@@ -56,6 +60,9 @@ void init_array(int ni, int nj, int nk, int nl,
 #endif
         D[i][j] = (DATA_TYPE) (i*(j+2) % nk) / nk;
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -114,6 +121,10 @@ void kernel_2mm(int ni, int nj, int nk, int nl,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static void
 kernel_2mm_StrictFP(int ni, int nj, int nk, int nl,
                          DATA_TYPE alpha,
@@ -143,6 +154,9 @@ kernel_2mm_StrictFP(int ni, int nj, int nk, int nl,
 	  D[i][j] += tmp[i][k] * C[k][j];
       }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/3mm/3mm.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/3mm/3mm.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array(int ni, int nj, int nk, int nl, int nm,
 		DATA_TYPE POLYBENCH_2D(A,NI,NK,ni,nk),
@@ -46,6 +50,9 @@ void init_array(int ni, int nj, int nk, int nl, int nm,
     for (j = 0; j < nl; j++)
       D[i][j] = (DATA_TYPE) ((i*(j+2)+2) % nk) / (5*nk);
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -113,6 +120,10 @@ void kernel_3mm(int ni, int nj, int nk, int nl, int nm,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void kernel_3mm_StrictFP(int ni, int nj, int nk, int nl, int nm,
                          DATA_TYPE POLYBENCH_2D(E,NI,NJ,ni,nj),
@@ -151,6 +162,9 @@ void kernel_3mm_StrictFP(int ni, int nj, int nk, int nl, int nm,
 	  G[i][j] += E[i][k] * F[k][j];
       }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/3mm/3mm.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/3mm/3mm.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array(int ni, int nj, int nk, int nl, int nm,
 		DATA_TYPE POLYBENCH_2D(A,NI,NK,ni,nk),
@@ -50,9 +47,6 @@ void init_array(int ni, int nj, int nk, int nl, int nm,
     for (j = 0; j < nl; j++)
       D[i][j] = (DATA_TYPE) ((i*(j+2)+2) % nk) / (5*nk);
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -120,10 +114,7 @@ void kernel_3mm(int ni, int nj, int nk, int nl, int nm,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void kernel_3mm_StrictFP(int ni, int nj, int nk, int nl, int nm,
                          DATA_TYPE POLYBENCH_2D(E,NI,NJ,ni,nj),
@@ -162,9 +153,6 @@ void kernel_3mm_StrictFP(int ni, int nj, int nk, int nl, int nm,
 	  G[i][j] += E[i][k] * F[k][j];
       }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/atax/atax.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/atax/atax.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int m, int n,
 		 DATA_TYPE POLYBENCH_2D(A,M,N,m,n),
@@ -43,9 +40,6 @@ void init_array (int m, int n,
     for (j = 0; j < n; j++)
       A[i][j] = (DATA_TYPE) ((i+j) % n) / (5*m);
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* DCE code. Must scan the entire live-out data.
    Can be used also to check the correctness of the output. */
@@ -94,10 +88,7 @@ void kernel_atax(int m, int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static void
 kernel_atax_StrictFP(int m, int n,
                           DATA_TYPE POLYBENCH_2D(A,M,N,m,n),
@@ -119,9 +110,6 @@ kernel_atax_StrictFP(int m, int n,
 	y[j] = y[j] + A[i][j] * tmp[i];
     }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/atax/atax.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/atax/atax.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int m, int n,
 		 DATA_TYPE POLYBENCH_2D(A,M,N,m,n),
@@ -39,6 +43,9 @@ void init_array (int m, int n,
     for (j = 0; j < n; j++)
       A[i][j] = (DATA_TYPE) ((i+j) % n) / (5*m);
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* DCE code. Must scan the entire live-out data.
    Can be used also to check the correctness of the output. */
@@ -87,6 +94,10 @@ void kernel_atax(int m, int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static void
 kernel_atax_StrictFP(int m, int n,
                           DATA_TYPE POLYBENCH_2D(A,M,N,m,n),
@@ -108,6 +119,9 @@ kernel_atax_StrictFP(int m, int n,
 	y[j] = y[j] + A[i][j] * tmp[i];
     }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/bicg/bicg.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/bicg/bicg.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int m, int n,
 		 DATA_TYPE POLYBENCH_2D(A,N,M,n,m),
@@ -44,9 +41,6 @@ void init_array (int m, int n,
       A[i][j] = (DATA_TYPE) (i*(j+1) % n)/n;
   }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -105,10 +99,7 @@ void kernel_bicg(int m, int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void kernel_bicg_StrictFP(int m, int n,
 		 DATA_TYPE POLYBENCH_2D(A,N,M,n,m),
@@ -132,9 +123,6 @@ void kernel_bicg_StrictFP(int m, int n,
 	}
     }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/bicg/bicg.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/bicg/bicg.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int m, int n,
 		 DATA_TYPE POLYBENCH_2D(A,N,M,n,m),
@@ -40,6 +44,9 @@ void init_array (int m, int n,
       A[i][j] = (DATA_TYPE) (i*(j+1) % n)/n;
   }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -98,6 +105,10 @@ void kernel_bicg(int m, int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void kernel_bicg_StrictFP(int m, int n,
 		 DATA_TYPE POLYBENCH_2D(A,N,M,n,m),
@@ -121,6 +132,9 @@ void kernel_bicg_StrictFP(int m, int n,
 	}
     }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/doitgen/doitgen.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/doitgen/doitgen.c
@@ -75,10 +75,6 @@ void print_array(int nr, int nq, int np,
 
 /* Main computational kernel. The whole function will be timed,
    including the call and return. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
 void kernel_doitgen(int nr, int nq, int np,
 		    DATA_TYPE POLYBENCH_3D(A,NR,NQ,NP,nr,nq,np),
 		    DATA_TYPE POLYBENCH_2D(C4,NP,NP,np,np),
@@ -105,6 +101,10 @@ void kernel_doitgen(int nr, int nq, int np,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 void kernel_doitgen_StrictFP(int nr, int nq, int np,
 		    DATA_TYPE POLYBENCH_3D(A,NR,NQ,NP,nr,nq,np),
 		    DATA_TYPE POLYBENCH_2D(C4,NP,NP,np,np),

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/doitgen/doitgen.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/doitgen/doitgen.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array(int nr, int nq, int np,
 		DATA_TYPE POLYBENCH_3D(A,NR,NQ,NP,nr,nq,np)
@@ -49,9 +46,6 @@ void init_array(int nr, int nq, int np,
     for (j = 0; j < np; j++)
       C4[i][j] = (DATA_TYPE) (i*j % np) / np;
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -101,10 +95,7 @@ void kernel_doitgen(int nr, int nq, int np,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 void kernel_doitgen_StrictFP(int nr, int nq, int np,
 		    DATA_TYPE POLYBENCH_3D(A,NR,NQ,NP,nr,nq,np),
 		    DATA_TYPE POLYBENCH_2D(C4,NP,NP,np,np),
@@ -124,9 +115,6 @@ void kernel_doitgen_StrictFP(int nr, int nq, int np,
 	A[r][q][p] = sum[p];
     }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/doitgen/doitgen.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/doitgen/doitgen.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array(int nr, int nq, int np,
 		DATA_TYPE POLYBENCH_3D(A,NR,NQ,NP,nr,nq,np)
@@ -45,6 +49,9 @@ void init_array(int nr, int nq, int np,
     for (j = 0; j < np; j++)
       C4[i][j] = (DATA_TYPE) (i*j % np) / np;
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -68,6 +75,10 @@ void print_array(int nr, int nq, int np,
 
 /* Main computational kernel. The whole function will be timed,
    including the call and return. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 void kernel_doitgen(int nr, int nq, int np,
 		    DATA_TYPE POLYBENCH_3D(A,NR,NQ,NP,nr,nq,np),
 		    DATA_TYPE POLYBENCH_2D(C4,NP,NP,np,np),
@@ -113,6 +124,9 @@ void kernel_doitgen_StrictFP(int nr, int nq, int np,
 	A[r][q][p] = sum[p];
     }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/mvt/mvt.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/mvt/mvt.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array(int n,
 		DATA_TYPE POLYBENCH_1D(x1,N,n),
@@ -58,9 +55,6 @@ void init_array(int n,
 	A[i][j] = (DATA_TYPE) (i*j % n) / n;
     }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -111,10 +105,7 @@ void kernel_mvt(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void kernel_mvt_StrictFP(int n,
                          DATA_TYPE POLYBENCH_1D(x1,N,n),
@@ -133,9 +124,6 @@ void kernel_mvt_StrictFP(int n,
     for (j = 0; j < _PB_N; j++)
       x2[i] = x2[i] + A[j][i] * y_2[j];
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/mvt/mvt.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/kernels/mvt/mvt.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array(int n,
 		DATA_TYPE POLYBENCH_1D(x1,N,n),
@@ -54,6 +58,9 @@ void init_array(int n,
 	A[i][j] = (DATA_TYPE) (i*j % n) / n;
     }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -104,6 +111,10 @@ void kernel_mvt(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void kernel_mvt_StrictFP(int n,
                          DATA_TYPE POLYBENCH_1D(x1,N,n),
@@ -122,6 +133,9 @@ void kernel_mvt_StrictFP(int n,
     for (j = 0; j < _PB_N; j++)
       x2[i] = x2[i] + A[j][i] * y_2[j];
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/cholesky/cholesky.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/cholesky/cholesky.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array(int n,
 		DATA_TYPE POLYBENCH_2D(A,N,N,n,n)
@@ -72,6 +76,9 @@ void init_array(int n,
   POLYBENCH_FREE_ARRAY(B);
 
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -125,6 +132,10 @@ void kernel_cholesky(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void kernel_cholesky_StrictFP(int n,
                               DATA_TYPE POLYBENCH_2D(A,N,N,n,n))
@@ -147,6 +158,9 @@ void kernel_cholesky_StrictFP(int n,
      A[i][i] = SQRT_FUN(A[i][i]);
   }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/cholesky/cholesky.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/cholesky/cholesky.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array(int n,
 		DATA_TYPE POLYBENCH_2D(A,N,N,n,n)
@@ -76,9 +73,6 @@ void init_array(int n,
   POLYBENCH_FREE_ARRAY(B);
 
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -132,10 +126,7 @@ void kernel_cholesky(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void kernel_cholesky_StrictFP(int n,
                               DATA_TYPE POLYBENCH_2D(A,N,N,n,n))
@@ -158,9 +149,6 @@ void kernel_cholesky_StrictFP(int n,
      A[i][i] = SQRT_FUN(A[i][i]);
   }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/durbin/durbin.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/durbin/durbin.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_1D(r,N,n))
@@ -35,6 +39,9 @@ void init_array (int n,
       r[i] = (n+1-i);
     }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -99,6 +106,10 @@ void kernel_durbin(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void kernel_durbin_StrictFP(int n,
                             DATA_TYPE POLYBENCH_1D(r,N,n),
@@ -132,6 +143,9 @@ void kernel_durbin_StrictFP(int n,
     y[k] = alpha;
   }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/durbin/durbin.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/durbin/durbin.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_1D(r,N,n))
@@ -39,9 +36,6 @@ void init_array (int n,
       r[i] = (n+1-i);
     }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -106,10 +100,7 @@ void kernel_durbin(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void kernel_durbin_StrictFP(int n,
                             DATA_TYPE POLYBENCH_1D(r,N,n),
@@ -143,9 +134,6 @@ void kernel_durbin_StrictFP(int n,
     y[k] = alpha;
   }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/gramschmidt/gramschmidt.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/gramschmidt/gramschmidt.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array(int m, int n,
 		DATA_TYPE POLYBENCH_2D(A,M,N,m,n),
@@ -41,6 +45,9 @@ void init_array(int m, int n,
     for (j = 0; j < n; j++)
       R[i][j] = 0.0;
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -116,6 +123,10 @@ void kernel_gramschmidt(int m, int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static void
 kernel_gramschmidt_StrictFP(int m, int n,
                             DATA_TYPE POLYBENCH_2D(A,M,N,m,n),
@@ -145,6 +156,9 @@ kernel_gramschmidt_StrictFP(int m, int n,
 	}
     }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/gramschmidt/gramschmidt.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/gramschmidt/gramschmidt.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array(int m, int n,
 		DATA_TYPE POLYBENCH_2D(A,M,N,m,n),
@@ -45,9 +42,6 @@ void init_array(int m, int n,
     for (j = 0; j < n; j++)
       R[i][j] = 0.0;
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -123,10 +117,7 @@ void kernel_gramschmidt(int m, int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static void
 kernel_gramschmidt_StrictFP(int m, int n,
                             DATA_TYPE POLYBENCH_2D(A,M,N,m,n),
@@ -156,9 +147,6 @@ kernel_gramschmidt_StrictFP(int m, int n,
 	}
     }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/lu/lu.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/lu/lu.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_2D(A,N,N,n,n))
@@ -57,6 +61,9 @@ void init_array (int n,
   POLYBENCH_FREE_ARRAY(B);
 
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -107,6 +114,10 @@ void kernel_lu(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static void
 kernel_lu_StrictFP(int n,
                    DATA_TYPE POLYBENCH_2D(A,N,N,n,n))
@@ -128,6 +139,9 @@ kernel_lu_StrictFP(int n,
     }
   }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 static inline int
 check_FP(int n,

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/lu/lu.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/lu/lu.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_2D(A,N,N,n,n))
@@ -61,9 +58,6 @@ void init_array (int n,
   POLYBENCH_FREE_ARRAY(B);
 
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -114,10 +108,7 @@ void kernel_lu(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static void
 kernel_lu_StrictFP(int n,
                    DATA_TYPE POLYBENCH_2D(A,N,N,n,n))
@@ -139,9 +130,6 @@ kernel_lu_StrictFP(int n,
     }
   }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 static inline int
 check_FP(int n,

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/ludcmp/ludcmp.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/ludcmp/ludcmp.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_2D(A,N,N,n,n),
@@ -72,9 +69,6 @@ void init_array (int n,
   POLYBENCH_FREE_ARRAY(B);
 
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -149,10 +143,7 @@ void kernel_ludcmp(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static void
 kernel_ludcmp_StrictFP(int n,
                        DATA_TYPE POLYBENCH_2D(A,N,N,n,n),
@@ -196,9 +187,6 @@ kernel_ludcmp_StrictFP(int n,
      x[i] = w / A[i][i];
   }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/ludcmp/ludcmp.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/ludcmp/ludcmp.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_2D(A,N,N,n,n),
@@ -68,6 +72,9 @@ void init_array (int n,
   POLYBENCH_FREE_ARRAY(B);
 
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -142,6 +149,10 @@ void kernel_ludcmp(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static void
 kernel_ludcmp_StrictFP(int n,
                        DATA_TYPE POLYBENCH_2D(A,N,N,n,n),
@@ -185,6 +196,9 @@ kernel_ludcmp_StrictFP(int n,
      x[i] = w / A[i][i];
   }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/trisolv/trisolv.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/trisolv/trisolv.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array(int n,
 		DATA_TYPE POLYBENCH_2D(L,N,N,n,n),
@@ -46,6 +50,9 @@ void init_array(int n,
 	L[i][j] = (DATA_TYPE) (i+n-j+1)*2/n;
     }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -91,6 +98,10 @@ void kernel_trisolv(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static void
 kernel_trisolv_StrictFP(int n,
                         DATA_TYPE POLYBENCH_2D(L,N,N,n,n),
@@ -108,6 +119,9 @@ kernel_trisolv_StrictFP(int n,
       x[i] = x[i] / L[i][i];
     }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/trisolv/trisolv.c
+++ b/SingleSource/Benchmarks/Polybench/linear-algebra/solvers/trisolv/trisolv.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array(int n,
 		DATA_TYPE POLYBENCH_2D(L,N,N,n,n),
@@ -50,9 +47,6 @@ void init_array(int n,
 	L[i][j] = (DATA_TYPE) (i+n-j+1)*2/n;
     }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -98,10 +92,7 @@ void kernel_trisolv(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static void
 kernel_trisolv_StrictFP(int n,
                         DATA_TYPE POLYBENCH_2D(L,N,N,n,n),
@@ -119,9 +110,6 @@ kernel_trisolv_StrictFP(int n,
       x[i] = x[i] / L[i][i];
     }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/medley/deriche/deriche.c
+++ b/SingleSource/Benchmarks/Polybench/medley/deriche/deriche.c
@@ -22,10 +22,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int w, int h, DATA_TYPE* alpha,
 		 DATA_TYPE POLYBENCH_2D(imgIn,W,H,w,h),
@@ -41,9 +38,6 @@ void init_array (int w, int h, DATA_TYPE* alpha,
      for (j = 0; j < h; j++)
 	imgIn[i][j] = (DATA_TYPE) ((313*i+991*j)%65536) / 65535.0f;
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -175,10 +169,7 @@ void kernel_deriche(int w, int h, DATA_TYPE alpha,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void kernel_deriche_StrictFP(int w, int h, DATA_TYPE alpha,
        DATA_TYPE POLYBENCH_2D(imgIn, W, H, w, h),
@@ -267,9 +258,6 @@ void kernel_deriche_StrictFP(int w, int h, DATA_TYPE alpha,
         for (j=0; j<_PB_H; j++)
             imgOut[i][j] = c2*(y1[i][j] + y2[i][j]);
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/medley/deriche/deriche.c
+++ b/SingleSource/Benchmarks/Polybench/medley/deriche/deriche.c
@@ -22,6 +22,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int w, int h, DATA_TYPE* alpha,
 		 DATA_TYPE POLYBENCH_2D(imgIn,W,H,w,h),
@@ -37,6 +41,9 @@ void init_array (int w, int h, DATA_TYPE* alpha,
      for (j = 0; j < h; j++)
 	imgIn[i][j] = (DATA_TYPE) ((313*i+991*j)%65536) / 65535.0f;
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -168,6 +175,10 @@ void kernel_deriche(int w, int h, DATA_TYPE alpha,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void kernel_deriche_StrictFP(int w, int h, DATA_TYPE alpha,
        DATA_TYPE POLYBENCH_2D(imgIn, W, H, w, h),
@@ -256,6 +267,9 @@ void kernel_deriche_StrictFP(int w, int h, DATA_TYPE alpha,
         for (j=0; j<_PB_H; j++)
             imgOut[i][j] = c2*(y1[i][j] + y2[i][j]);
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/medley/floyd-warshall/floyd-warshall.c
+++ b/SingleSource/Benchmarks/Polybench/medley/floyd-warshall/floyd-warshall.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_2D(path,N,N,n,n))
@@ -37,6 +41,9 @@ void init_array (int n,
          path[i][j] = 999;
     }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -82,6 +89,10 @@ void kernel_floyd_warshall(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static void
 kernel_floyd_warshall_StrictFP(int n, DATA_TYPE POLYBENCH_2D(path,N,N,n,n))
 {
@@ -96,6 +107,9 @@ kernel_floyd_warshall_StrictFP(int n, DATA_TYPE POLYBENCH_2D(path,N,N,n,n))
 	    path[i][j] : path[i][k] + path[k][j];
     }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/medley/floyd-warshall/floyd-warshall.c
+++ b/SingleSource/Benchmarks/Polybench/medley/floyd-warshall/floyd-warshall.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_2D(path,N,N,n,n))
@@ -41,9 +38,6 @@ void init_array (int n,
          path[i][j] = 999;
     }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -89,10 +83,7 @@ void kernel_floyd_warshall(int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static void
 kernel_floyd_warshall_StrictFP(int n, DATA_TYPE POLYBENCH_2D(path,N,N,n,n))
 {
@@ -107,9 +98,6 @@ kernel_floyd_warshall_StrictFP(int n, DATA_TYPE POLYBENCH_2D(path,N,N,n,n))
 	    path[i][j] : path[i][k] + path[k][j];
     }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/medley/nussinov/nussinov.c
+++ b/SingleSource/Benchmarks/Polybench/medley/nussinov/nussinov.c
@@ -27,10 +27,7 @@ typedef char base;
 #define max_score(s1, s2) ((s1 >= s2) ? s1 : s2)
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int n,
                  base POLYBENCH_1D(seq,N,n),
@@ -48,9 +45,6 @@ void init_array (int n,
      for (j=0; j <n; j++)
        table[i][j] = 0;
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -115,10 +109,7 @@ void kernel_nussinov(int n, base POLYBENCH_1D(seq,N,n),
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void kernel_nussinov_StrictFP(int n, base POLYBENCH_1D(seq,N,n),
 			   DATA_TYPE POLYBENCH_2D(table,N,N,n,n))
@@ -148,9 +139,6 @@ void kernel_nussinov_StrictFP(int n, base POLYBENCH_1D(seq,N,n),
   }
  }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/medley/nussinov/nussinov.c
+++ b/SingleSource/Benchmarks/Polybench/medley/nussinov/nussinov.c
@@ -27,6 +27,10 @@ typedef char base;
 #define max_score(s1, s2) ((s1 >= s2) ? s1 : s2)
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int n,
                  base POLYBENCH_1D(seq,N,n),
@@ -44,6 +48,9 @@ void init_array (int n,
      for (j=0; j <n; j++)
        table[i][j] = 0;
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -108,6 +115,10 @@ void kernel_nussinov(int n, base POLYBENCH_1D(seq,N,n),
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void kernel_nussinov_StrictFP(int n, base POLYBENCH_1D(seq,N,n),
 			   DATA_TYPE POLYBENCH_2D(table,N,N,n,n))
@@ -137,6 +148,9 @@ void kernel_nussinov_StrictFP(int n, base POLYBENCH_1D(seq,N,n),
   }
  }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/stencils/adi/adi.c
+++ b/SingleSource/Benchmarks/Polybench/stencils/adi/adi.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_2D(u,N,N,n,n))
@@ -36,6 +40,9 @@ void init_array (int n,
 	u[i][j] =  (DATA_TYPE)(i + n-j) / n;
       }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -127,6 +134,10 @@ void kernel_adi(int tsteps, int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static void
 kernel_adi_StrictFP(int tsteps,
                     int n,
@@ -189,6 +200,9 @@ kernel_adi_StrictFP(int tsteps,
     }
   }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/stencils/adi/adi.c
+++ b/SingleSource/Benchmarks/Polybench/stencils/adi/adi.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_2D(u,N,N,n,n))
@@ -40,9 +37,6 @@ void init_array (int n,
 	u[i][j] =  (DATA_TYPE)(i + n-j) / n;
       }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -134,10 +128,7 @@ void kernel_adi(int tsteps, int n,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static void
 kernel_adi_StrictFP(int tsteps,
                     int n,
@@ -200,9 +191,6 @@ kernel_adi_StrictFP(int tsteps,
     }
   }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/stencils/fdtd-2d/fdtd-2d.c
+++ b/SingleSource/Benchmarks/Polybench/stencils/fdtd-2d/fdtd-2d.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int tmax,
 		 int nx,
@@ -45,6 +49,9 @@ void init_array (int tmax,
 	hz[i][j] = ((DATA_TYPE) i*(j+3)) / nx;
       }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -112,6 +119,10 @@ void kernel_fdtd_2d(int tmax,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static void
 kernel_fdtd_2d_StrictFP(int tmax,
                         int nx,
@@ -140,6 +151,9 @@ kernel_fdtd_2d_StrictFP(int tmax,
 				       ey[i+1][j] - ey[i][j]);
     }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/stencils/fdtd-2d/fdtd-2d.c
+++ b/SingleSource/Benchmarks/Polybench/stencils/fdtd-2d/fdtd-2d.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int tmax,
 		 int nx,
@@ -49,9 +46,6 @@ void init_array (int tmax,
 	hz[i][j] = ((DATA_TYPE) i*(j+3)) / nx;
       }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -119,10 +113,7 @@ void kernel_fdtd_2d(int tmax,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static void
 kernel_fdtd_2d_StrictFP(int tmax,
                         int nx,
@@ -151,9 +142,6 @@ kernel_fdtd_2d_StrictFP(int tmax,
 				       ey[i+1][j] - ey[i][j]);
     }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/stencils/heat-3d/heat-3d.c
+++ b/SingleSource/Benchmarks/Polybench/stencils/heat-3d/heat-3d.c
@@ -22,6 +22,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_3D(A,N,N,N,n,n,n),
@@ -35,6 +39,9 @@ void init_array (int n,
       for (k = 0; k < n; k++)
         A[i][j][k] = B[i][j][k] = (DATA_TYPE) (i + j + (n-k))* 10 / (n);
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -100,6 +107,10 @@ void kernel_heat_3d(int tsteps,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void kernel_heat_3d_StrictFP(int tsteps,
 		      int n,
@@ -133,6 +144,9 @@ void kernel_heat_3d_StrictFP(int tsteps,
     }
 
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/stencils/heat-3d/heat-3d.c
+++ b/SingleSource/Benchmarks/Polybench/stencils/heat-3d/heat-3d.c
@@ -22,10 +22,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_3D(A,N,N,N,n,n,n),
@@ -39,9 +36,6 @@ void init_array (int n,
       for (k = 0; k < n; k++)
         A[i][j][k] = B[i][j][k] = (DATA_TYPE) (i + j + (n-k))* 10 / (n);
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -107,10 +101,7 @@ void kernel_heat_3d(int tsteps,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void kernel_heat_3d_StrictFP(int tsteps,
 		      int n,
@@ -144,9 +135,6 @@ void kernel_heat_3d_StrictFP(int tsteps,
     }
 
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/stencils/jacobi-1d/jacobi-1d.c
+++ b/SingleSource/Benchmarks/Polybench/stencils/jacobi-1d/jacobi-1d.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_1D(A,N,n),
@@ -37,6 +41,9 @@ void init_array (int n,
 	B[i] = ((DATA_TYPE) i+ 3) / n;
       }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -82,6 +89,10 @@ void kernel_jacobi_1d(int tsteps,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static void
 kernel_jacobi_1d_StrictFP(int tsteps,
                                 int n,
@@ -99,6 +110,9 @@ kernel_jacobi_1d_StrictFP(int tsteps,
 	A[i] = 0.33333 * (B[i-1] + B[i] + B[i + 1]);
     }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/stencils/jacobi-1d/jacobi-1d.c
+++ b/SingleSource/Benchmarks/Polybench/stencils/jacobi-1d/jacobi-1d.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_1D(A,N,n),
@@ -41,9 +38,6 @@ void init_array (int n,
 	B[i] = ((DATA_TYPE) i+ 3) / n;
       }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -89,10 +83,7 @@ void kernel_jacobi_1d(int tsteps,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static void
 kernel_jacobi_1d_StrictFP(int tsteps,
                                 int n,
@@ -110,9 +101,6 @@ kernel_jacobi_1d_StrictFP(int tsteps,
 	A[i] = 0.33333 * (B[i-1] + B[i] + B[i + 1]);
     }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/stencils/jacobi-2d/jacobi-2d.c
+++ b/SingleSource/Benchmarks/Polybench/stencils/jacobi-2d/jacobi-2d.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_2D(A,N,N,n,n),
@@ -38,6 +42,9 @@ void init_array (int n,
 	B[i][j] = ((DATA_TYPE) i*(j+3) + 3) / n;
       }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -87,6 +94,10 @@ void kernel_jacobi_2d(int tsteps,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static void
 kernel_jacobi_2d_StrictFP(int tsteps,
                                 int n,
@@ -106,6 +117,9 @@ kernel_jacobi_2d_StrictFP(int tsteps,
 	  A[i][j] = SCALAR_VAL(0.2) * (B[i][j] + B[i][j-1] + B[i][1+j] + B[1+i][j] + B[i-1][j]);
     }
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/stencils/jacobi-2d/jacobi-2d.c
+++ b/SingleSource/Benchmarks/Polybench/stencils/jacobi-2d/jacobi-2d.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_2D(A,N,N,n,n),
@@ -42,9 +39,6 @@ void init_array (int n,
 	B[i][j] = ((DATA_TYPE) i*(j+3) + 3) / n;
       }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -94,10 +88,7 @@ void kernel_jacobi_2d(int tsteps,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static void
 kernel_jacobi_2d_StrictFP(int tsteps,
                                 int n,
@@ -117,9 +108,6 @@ kernel_jacobi_2d_StrictFP(int tsteps,
 	  A[i][j] = SCALAR_VAL(0.2) * (B[i][j] + B[i][j-1] + B[i][1+j] + B[1+i][j] + B[i-1][j]);
     }
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/stencils/seidel-2d/seidel-2d.c
+++ b/SingleSource/Benchmarks/Polybench/stencils/seidel-2d/seidel-2d.c
@@ -23,10 +23,7 @@
 
 
 /* Array initialization. */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_2D(A,N,N,n,n))
@@ -38,9 +35,6 @@ void init_array (int n,
     for (j = 0; j < n; j++)
       A[i][j] = ((DATA_TYPE) i*(j+2) + 2) / n;
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -86,10 +80,7 @@ void kernel_seidel_2d(int tsteps,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC push_options
-#pragma GCC optimize ("fp-contract=off")
-#endif
+POLYBENCH_GCC_FP_CONTRACT_OFF
 static void
 kernel_seidel_2d_StrictFP(int tsteps,
                           int n,
@@ -105,9 +96,6 @@ kernel_seidel_2d_StrictFP(int tsteps,
 		   + A[i][j-1] + A[i][j] + A[i][j+1]
 		   + A[i+1][j-1] + A[i+1][j] + A[i+1][j+1])/SCALAR_VAL(9.0);
 }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/stencils/seidel-2d/seidel-2d.c
+++ b/SingleSource/Benchmarks/Polybench/stencils/seidel-2d/seidel-2d.c
@@ -23,6 +23,10 @@
 
 
 /* Array initialization. */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static
 void init_array (int n,
 		 DATA_TYPE POLYBENCH_2D(A,N,N,n,n))
@@ -34,6 +38,9 @@ void init_array (int n,
     for (j = 0; j < n; j++)
       A[i][j] = ((DATA_TYPE) i*(j+2) + 2) / n;
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 
 /* DCE code. Must scan the entire live-out data.
@@ -79,6 +86,10 @@ void kernel_seidel_2d(int tsteps,
 // NOTE: FMA_DISABLED is true for targets where FMA contraction causes
 // discrepancies which cause the accuracy checks to fail.
 // In this case, the test runs with the option -ffp-contract=off
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 static void
 kernel_seidel_2d_StrictFP(int tsteps,
                           int n,
@@ -94,6 +105,9 @@ kernel_seidel_2d_StrictFP(int tsteps,
 		   + A[i][j-1] + A[i][j] + A[i][j+1]
 		   + A[i+1][j-1] + A[i+1][j] + A[i+1][j+1])/SCALAR_VAL(9.0);
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Return 0 when one of the elements of arrays A and B do not match within the
    allowed FP_ABSTOLERANCE.  Return 1 when all elements match.  */

--- a/SingleSource/Benchmarks/Polybench/utilities/polybench.h
+++ b/SingleSource/Benchmarks/Polybench/utilities/polybench.h
@@ -73,6 +73,12 @@
 #  define POLYBENCH_RESTRICT
 # endif
 
+# if defined(__GNUC__) && !defined(__clang__)
+#  define POLYBENCH_GCC_FP_CONTRACT_OFF __attribute__((optimize("fp-contract=off")))
+# else
+#  define POLYBENCH_GCC_FP_CONTRACT_OFF
+# endif
+
 /* Macros to reference an array. Generic for heap and stack arrays
    (C99).  Each array dimensionality has his own macro, to be used at
    declaration or as a function argument.


### PR DESCRIPTION
Similar to #440, this implements the same fix for any polybench test that relies on #pragma STDC FP_CONTRACT OFF, which isn't supported on GCC and causes mismatched results.

Outside of these two PRs there doesn't seem to be any other users of the pragma.

The changes in this PR were written by Claude