### PR TITLE
[flang][OpenMP] Update test expectation for collapse on imperfectly nested loop (attempt #2)

### DIFF
--- a/Fortran/gfortran/regression/gomp/override.yaml
+++ b/Fortran/gfortran/regression/gomp/override.yaml
@@ -5,3 +5,6 @@
 
 "allocate-16.f90":
   xfail: false
+
+"imperfect2.f90":
+  xfail: false

--- a/Fortran/gfortran/regression/gomp/tests.cmake
+++ b/Fortran/gfortran/regression/gomp/tests.cmake
@@ -226,7 +226,7 @@ compile;if-1.f90;;;;
 compile;imperfect-gotos.f90;xfail;;;
 compile;imperfect-invalid-scope.f90;xfail;;;
 compile;imperfect1.f90;xfail;;;
-compile;imperfect2.f90;xfail;;;
+compile;imperfect2.f90;;;;
 compile;imperfect3.f90;xfail;;;
 compile;imperfect4.f90;xfail;;;
 compile;imperfect5.f90;xfail;;;

--- a/Fortran/gfortran/regression/gomp/tests.cmake
+++ b/Fortran/gfortran/regression/gomp/tests.cmake
@@ -226,7 +226,7 @@ compile;if-1.f90;;;;
 compile;imperfect-gotos.f90;xfail;;;
 compile;imperfect-invalid-scope.f90;xfail;;;
 compile;imperfect1.f90;xfail;;;
-compile;imperfect2.f90;;;;
+compile;imperfect2.f90;xfail;;;
 compile;imperfect3.f90;xfail;;;
 compile;imperfect4.f90;xfail;;;
 compile;imperfect5.f90;xfail;;;


### PR DESCRIPTION
Collapse is now implemented for imperfectly nested loops in https://github.com/llvm/llvm-project/pull/202435.
Relates to issue: https://github.com/llvm/llvm-project/issues/199092