### PR TITLE
Define UNALIGNED_MEM_ACCESS_NOT_SUPPORTED in ALAC test for RISC-V when needed

### DIFF
--- a/MultiSource/Applications/ALAC/decode/CMakeLists.txt
+++ b/MultiSource/Applications/ALAC/decode/CMakeLists.txt
@@ -11,6 +11,15 @@ if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "sparc")
   list(APPEND CXXFLAGS -DUNALIGNED_MEM_ACCESS_NOT_SUPPORTED)
 endif()
 
+if(ARCH MATCHES "riscv")
+  include(CheckSymbolExists)
+  check_symbol_exists(__riscv_misaligned_avoid "" RISCV_MISALIGNED_AVOID)
+  if(RISCV_MISALIGNED_AVOID)
+    list(APPEND CFLAGS -DUNALIGNED_MEM_ACCESS_NOT_SUPPORTED)
+    list(APPEND CXXFLAGS -DUNALIGNED_MEM_ACCESS_NOT_SUPPORTED)
+  endif()
+endif()
+
 set(RUN_OPTIONS - - < tune.caf)
 llvm_multisource(alacconvert-decode
   EndianPortable.c

--- a/MultiSource/Applications/ALAC/encode/CMakeLists.txt
+++ b/MultiSource/Applications/ALAC/encode/CMakeLists.txt
@@ -11,6 +11,15 @@ if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "sparc")
   list(APPEND CXXFLAGS -DUNALIGNED_MEM_ACCESS_NOT_SUPPORTED)
 endif()
 
+if(ARCH MATCHES "riscv")
+  include(CheckSymbolExists)
+  check_symbol_exists(__riscv_misaligned_avoid "" RISCV_MISALIGNED_AVOID)
+  if(RISCV_MISALIGNED_AVOID)
+    list(APPEND CFLAGS -DUNALIGNED_MEM_ACCESS_NOT_SUPPORTED)
+    list(APPEND CXXFLAGS -DUNALIGNED_MEM_ACCESS_NOT_SUPPORTED)
+  endif()
+endif()
+
 set(RUN_OPTIONS - - < tune.wav)
 llvm_multisource(alacconvert-encode
   EndianPortable.c


### PR DESCRIPTION
ag_enc.c casts uint8_t* to uint32_t* to read and write big-endian 32-bit values. The compiler assumes a uint32_t* is aligned and emits a full-word load/store, which traps on RISC-V without misaligned load/store support.

Enable it for RISC-V targets whose compiler defines __riscv_misaligned_avoid, so targets that support misaligned accesses keep using the word-sized path.