### PR TITLE
[Fortran] declare-variant-6 is now passing after LLVM's PR #206988

### DIFF
--- a/Fortran/gfortran/regression/gomp/tests.cmake
+++ b/Fortran/gfortran/regression/gomp/tests.cmake
@@ -171,7 +171,7 @@ compile;declare-variant-2a.f90;xfail;;;
 compile;declare-variant-3.f90;;;;
 compile;declare-variant-4.f90;;;;
 compile;declare-variant-5.f90;;;i.86-.+-.+ x86_64-.+-.+;
-compile;declare-variant-6.f90;xfail;;;
+compile;declare-variant-6.f90;;;;
 compile;declare-variant-7.f90;xfail;;i.86-.+-.+ x86_64-.+-.+;
 compile;declare-variant-8.f90;;;;
 compile;declare-variant-9.f90;;-cpp;;


### PR DESCRIPTION
See this PR: https://github.com/llvm/llvm-project/pull/206988