### PR TITLE
[Fortran] Add namelist/ UnitTest for the empty-scalar extension

### DIFF
--- a/Fortran/UnitTests/CMakeLists.txt
+++ b/Fortran/UnitTests/CMakeLists.txt
@@ -7,3 +7,4 @@ add_subdirectory(execute_command_line)
 add_subdirectory(fcvs21_f95) # NIST Fortran Compiler Validation Suite
 add_subdirectory(finalization)
 add_subdirectory(fp_conversions)
+add_subdirectory(namelist)

--- a/Fortran/UnitTests/namelist/CMakeLists.txt
+++ b/Fortran/UnitTests/namelist/CMakeLists.txt
@@ -1,0 +1,3 @@
+llvm_singlesource()
+
+file(COPY lit.local.cfg DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")

--- a/Fortran/UnitTests/namelist/lit.local.cfg
+++ b/Fortran/UnitTests/namelist/lit.local.cfg
@@ -1,0 +1,2 @@
+config.traditional_output = False
+config.single_source = True

--- a/Fortran/UnitTests/namelist/namelist_empty_scalar.f90
+++ b/Fortran/UnitTests/namelist/namelist_empty_scalar.f90
@@ -1,0 +1,36 @@
+! Flang NAMELIST extension: an assignment to a scalar item may omit its
+! value (e.g. `l_flag=`, immediately followed by the next name-value
+! pair or the group terminator), leaving the item's current value
+! unchanged.  F2023 13.11.3.2 requires a value token to follow the `=`,
+! but nvfortran and gfortran accept the empty form as "keep current
+! value".  See flang/docs/Extensions.md.
+!
+! This test exercises both spelling variants:
+!   * l_flag= i_count=7      (no whitespace around `=`)
+!   * l_flag = i_count = 7   (whitespace on both sides of `=`)
+! In each case l_flag must retain its .true. value and i_count must
+! be set to 7 from the following assignment.
+
+program p
+  implicit none
+  logical :: l_flag
+  integer :: i_count
+  character(len=64) :: buf
+  namelist /test_nml/ l_flag, i_count
+
+  ! Form 1: no whitespace around the `=`.
+  l_flag = .true.
+  i_count = 42
+  buf = "&test_nml l_flag= i_count=7 /"
+  read(buf, nml=test_nml)
+  if (.not. l_flag) stop 1
+  if (i_count /= 7) stop 2
+
+  ! Form 2: whitespace on both sides of the `=`.
+  l_flag = .true.
+  i_count = 42
+  buf = "&test_nml l_flag = i_count = 7 /"
+  read(buf, nml=test_nml)
+  if (.not. l_flag) stop 3
+  if (i_count /= 7) stop 4
+end program

--- a/Fortran/UnitTests/namelist/namelist_empty_scalar.f90
+++ b/Fortran/UnitTests/namelist/namelist_empty_scalar.f90
@@ -1,7 +1,7 @@
 ! Flang NAMELIST extension: an assignment to a scalar item may omit its
 ! value (e.g. `l_flag=`, immediately followed by the next name-value
 ! pair or the group terminator), leaving the item's current value
-! unchanged.  F2023 13.11.3.2 requires a value token to follow the `=`,
+! unchanged.  F2023 13.11.2 p1 requires a value token to follow the `=`,
 ! but nvfortran and gfortran accept the empty form as "keep current
 ! value".  See flang/docs/Extensions.md.
 !


### PR DESCRIPTION
Covers Flang's NAMELIST extension that accepts an empty assignment to a scalar item (e.g. `l_flag=` immediately followed by the next name-value pair or the group terminator), leaving the item at its current value.  See flang/docs/Extensions.md.

The single test file exercises both spellings — `l_flag= i_count=7` with no whitespace around `=`, and `l_flag = i_count = 7` with whitespace on both sides — and uses `stop N` to signal per-check failure, following the pattern of the sibling UnitTests (binary_edit, fcvs21_f95, ...).  The directory is named `namelist/` (not `namelist_empty_scalar/`) so future NAMELIST extension tests can accrete alongside without another CMake subdirectory.