### PR TITLE
[HashRecognize] Avoid CMake race condition when copying reference output

### DIFF
--- a/SingleSource/UnitTests/HashRecognize/CMakeLists.txt
+++ b/SingleSource/UnitTests/HashRecognize/CMakeLists.txt
@@ -8,7 +8,7 @@ if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
     set(BASE_CFLAGS ${CFLAGS})
 
     list(APPEND CFLAGS "-mllvm" "-disable-loop-idiom-hashrecognize")
-    llvm_singlesource(PREFIX "no-hr-")
+    llvm_singlesource(PREFIX "no-hr-" DEST_SUFFIX "-no-hr")
     set(CFLAGS ${BASE_CFLAGS})
   endif()
 endif()


### PR DESCRIPTION
The two tested variants of the HashRecognize tests (HashRecognize enabled/disabled) use different test prefixes, but use the same reference output file. This seems to be causing spurious failures with LLVM BuildBot in a manner very similar to what was seen in #381. To fix, simply add a `DEST_SUFFIX` as introduced in the aforementioned PR, so that each test copies its reference output to a distinct path.

Assisted-by: Claude