### PR TITLE
[SPEC] Fix gobmk with -fwrapv-pointer

### DIFF
--- a/External/SPEC/CINT2006/445.gobmk/CMakeLists.txt
+++ b/External/SPEC/CINT2006/445.gobmk/CMakeLists.txt
@@ -1,6 +1,14 @@
 list(APPEND CPPFLAGS -DWANT_STDC_PROTO)
 list(APPEND LDFLAGS -lm)
 
+include(CheckCXXCompilerFlag)
+
+check_cxx_compiler_flag(-fwrapv-pointer
+                        HAVE_CXX_FLAG_FWRAPV_POINTER)
+if(HAVE_CXX_FLAG_FWRAPV_POINTER)
+  add_compile_options(-fwrapv-pointer)
+endif()
+
 set(Source "")
 foreach(dir IN ITEMS
         src/sgf src/engine src/interface src/patterns src/utils src)


### PR DESCRIPTION
Fixes pointer arithmetic UB that causes failures with recent clang.

Similar to xalancbmk fix in 0c27673ac.

https://discourse.llvm.org/t/is-anyone-else-seeing-an-error-in-spec2k6-445-gobmk-using-just-scalar/85752