### PR TITLE
[Fortran] Add a test for BIND(C) derived types passed by value

### DIFF
--- a/Fortran/UnitTests/CMakeLists.txt
+++ b/Fortran/UnitTests/CMakeLists.txt
@@ -8,3 +8,4 @@ add_subdirectory(fcvs21_f95) # NIST Fortran Compiler Validation Suite
 add_subdirectory(finalization)
 add_subdirectory(fp_conversions)
 add_subdirectory(namelist)
+add_subdirectory(bind-c-value)

--- a/Fortran/UnitTests/bind-c-value/CMakeLists.txt
+++ b/Fortran/UnitTests/bind-c-value/CMakeLists.txt
@@ -1,3 +1,7 @@
-llvm_multisource(bind-c-value)
+# BIND(C) is not implemented for x86_64 Windows, so do not enable the test on
+# Windows yet.
+if (NOT WIN32)
+  llvm_multisource(bind-c-value)
 
-file(COPY lit.local.cfg DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+  file(COPY lit.local.cfg DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+endif()

--- a/Fortran/UnitTests/bind-c-value/CMakeLists.txt
+++ b/Fortran/UnitTests/bind-c-value/CMakeLists.txt
@@ -1,0 +1,3 @@
+llvm_multisource(bind-c-value)
+
+file(COPY lit.local.cfg DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")

--- a/Fortran/UnitTests/bind-c-value/bind-c-value-c.c
+++ b/Fortran/UnitTests/bind-c-value/bind-c-value-c.c
@@ -1,0 +1,32 @@
+/* Companion file for bind-c-value.f90. Each function checks the contents of a
+   derived type that was passed by value from Fortran, so a mismatch means the
+   argument was not passed according to the ABI. */
+
+#include <stdlib.h>
+
+typedef struct { char a[16]; } t16;
+typedef struct { char a[17]; } t17;
+typedef struct { char a[128]; } t128;
+
+static void check_contents(const char *a, int n) {
+  int i;
+
+  for (i = 0; i < n; i++)
+    if (a[i] != (char)(i % 127 + 1))
+      abort();
+}
+
+void check_t16(t16 x) { check_contents(x.a, 16); }
+
+void check_t17(t17 x) { check_contents(x.a, 17); }
+
+void check_t128(t128 x) { check_contents(x.a, 128); }
+
+/* A derived type that is passed as a pointer to a copy still uses an argument
+   register, so i and j must arrive in the registers that follow it. */
+
+void check_mixed(void *p, int i, t128 x, int j) {
+  if (p != NULL || i != 11 || j != 22)
+    abort();
+  check_contents(x.a, 128);
+}

--- a/Fortran/UnitTests/bind-c-value/bind-c-value.f90
+++ b/Fortran/UnitTests/bind-c-value/bind-c-value.f90
@@ -1,0 +1,82 @@
+! Check that a BIND(C) derived type dummy argument with the VALUE attribute is
+! passed correctly to a C function. A derived type that is larger than 16 bytes
+! cannot be passed in registers on some targets, and is instead passed as a
+! pointer to a copy made by the caller. This also checks that arguments
+! following such a derived type are still passed correctly.
+
+module m
+  use iso_c_binding
+  implicit none
+
+  ! Small enough to be passed in registers.
+  type, bind(c) :: t16
+    character(c_char) :: a(16)
+  end type
+
+  ! The smallest size that is too large to be passed in registers.
+  type, bind(c) :: t17
+    character(c_char) :: a(17)
+  end type
+
+  type, bind(c) :: t128
+    character(c_char) :: a(128)
+  end type
+
+  interface
+    subroutine check_t16(x) bind(c, name="check_t16")
+      import :: t16
+      type(t16), value :: x
+    end subroutine
+
+    subroutine check_t17(x) bind(c, name="check_t17")
+      import :: t17
+      type(t17), value :: x
+    end subroutine
+
+    subroutine check_t128(x) bind(c, name="check_t128")
+      import :: t128
+      type(t128), value :: x
+    end subroutine
+
+    subroutine check_mixed(p, i, x, j) bind(c, name="check_mixed")
+      import :: c_ptr, c_int, t128
+      type(c_ptr), value :: p
+      integer(c_int), value :: i
+      type(t128), value :: x
+      integer(c_int), value :: j
+    end subroutine
+  end interface
+
+end module
+
+program bind_c_value
+  use iso_c_binding
+  use m
+  implicit none
+
+  type(t16) :: x16
+  type(t17) :: x17
+  type(t128) :: x128
+  integer :: i
+
+  ! Use values in the range 1 to 127 so that they are positive whether or not
+  ! the C compiler treats char as signed.
+  do i = 1, 16
+    x16%a(i) = char(mod(i - 1, 127) + 1)
+  end do
+  do i = 1, 17
+    x17%a(i) = char(mod(i - 1, 127) + 1)
+  end do
+  do i = 1, 128
+    x128%a(i) = char(mod(i - 1, 127) + 1)
+  end do
+
+  ! Each of these aborts if the argument did not arrive intact.
+  call check_t16(x16)
+  call check_t17(x17)
+  call check_t128(x128)
+  call check_mixed(c_null_ptr, 11, x128, 22)
+
+  print *, 'All arguments passed correctly'
+
+end program bind_c_value

--- a/Fortran/UnitTests/bind-c-value/bind-c-value.reference_output
+++ b/Fortran/UnitTests/bind-c-value/bind-c-value.reference_output
@@ -1,0 +1,2 @@
+ All arguments passed correctly
+exit 0

--- a/Fortran/UnitTests/bind-c-value/lit.local.cfg
+++ b/Fortran/UnitTests/bind-c-value/lit.local.cfg
@@ -1,0 +1,2 @@
+config.traditional_output = True
+config.single_source = False


### PR DESCRIPTION
Check that a BIND(C) derived type dummy argument with the VALUE attribute is passed correctly to a C function, for sizes that are small enough to be passed in registers and for sizes that are not. Also check that arguments following such a derived type are passed correctly, since a derived type that is passed as a pointer to a copy still uses an argument register.

This is a run test that calls into C, so it covers both the caller and the callee side of the interface.

The AArch64 case is fixed by https://github.com/llvm/llvm-project/pull/215508.